### PR TITLE
Dbr 100 user menu bug

### DIFF
--- a/assets/scss/templates/_header.scss
+++ b/assets/scss/templates/_header.scss
@@ -239,14 +239,6 @@
     align-items: center;
   }
 
-  span {
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    max-width: 248px;
-    display: block;
-    overflow: hidden;
-  }
-
   header p {
     margin-left: 10px;
   }

--- a/assets/scss/templates/_header.scss
+++ b/assets/scss/templates/_header.scss
@@ -195,10 +195,7 @@
   }
 }
 
-.user-menu.open {
-  visibility: visible;
-  opacity: 1;
-}
+
 
 .user-menu {
   background: $dp-color-white;
@@ -234,37 +231,46 @@
     top: -7px;
   }
 
+  &.open {
+    visibility: visible;
+    opacity: 1;
+  }
+
   header {
     display: flex;
     align-items: center;
+
+    p {
+      margin-left: 10px;
+
+      span {
+        @include do-ellipsis(248px, block);
+      }
+    }
+
+    .email {
+      color: $dp-color-grey;
+      font-size: $dp-font-size-small;
+    }
+
+    .name {
+      color: $dp-color-darkgrey;
+      font-size: 20px;
+    }
   }
 
-  header p {
-    margin-left: 10px;
-  }
+  .options-user {
+    li {
+      border-top: 1px solid $dp-border-grey;
+      padding: 12px 0;
+      display: flex;
+      font-size: 11px;
+    }
 
-  header .email {
-    color: $dp-color-grey;
-    font-size: $dp-font-size-small;
-  }
-
-  .name {
-    color: $dp-color-darkgrey;
-    font-size: 20px;
-  }
-}
-
-.user-menu .options-user {
-  li {
-    border-top: 1px solid $dp-border-grey;
-    padding: 12px 0;
-    display: flex;
-    font-size: 11px;
-  }
-
-  a {
-    font-size: $dp-font-size-small;
-    color: $dp-color-grey;
+    a {
+      font-size: $dp-font-size-small;
+      color: $dp-color-grey;
+    }
   }
 }
 

--- a/assets/scss/utilities/_ellipsis.scss
+++ b/assets/scss/utilities/_ellipsis.scss
@@ -1,0 +1,29 @@
+////
+/// Ellipsis
+/// @group utilities
+/// @access private
+/// @author Damián Muti
+////
+
+/// Create ellipsis on an element.
+/// @param {number} $max-width - Max width of the element that needs to be truncated.
+/// @param {string} $display - Display value of the element.  Accepted values: `block` or `inline-block`.
+/// @example scss - Usage
+///  span {
+///    @include do-ellipsis(200px, inline-block);
+///  }
+
+@mixin do-ellipsis($max-width, $display) {
+  @if type-of($max-width) != number {
+    @error "Max-width must be a length value. E.g: `1em`.";
+  }
+  @if not index(block inline-block, $display) {
+    @error "Display must be either `block` or `inline-block`.";
+  }
+
+  max-width: if(unitless($max-width), $max-width * 1px, $max-width);
+  display: $display;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}


### PR DESCRIPTION
Besides removing the styles that were unused and were affecting the structure for the user menu, I've created a mixin to handle ellipsis on elements.
This mixin is intended for internal usage, meaning that this will help Library creators do ellipsis on elements based on given attrs.