### PR TITLE
feat: Adjust margins to see the create account button on a 650px high…

### DIFF
--- a/assets/scss/core/_base.scss
+++ b/assets/scss/core/_base.scss
@@ -114,11 +114,11 @@ textarea {
     text-align: left;
     float: left;
     width: 100%;
-    margin-bottom: $dp-spaces--lv5;
+    margin-bottom: $dp-spaces--lv3;
 
     &__checkbox {
       cursor: pointer;
-      margin-bottom: $dp-spaces--lv3;
+      margin-bottom: $dp-spaces--lv2;
 
       label {
         font-weight: normal;
@@ -127,7 +127,7 @@ textarea {
       }
 
       &:nth-last-child(1) {
-        margin-bottom: $dp-spaces--lv4;
+        margin-bottom: $dp-spaces--lv3;
       }
     }/* Field checkbox */
 

--- a/assets/scss/modules/_forms.scss
+++ b/assets/scss/modules/_forms.scss
@@ -58,7 +58,7 @@
 /* signup form */
 
 .signup-form {
-  margin-top: $dp-spaces--lv6;
+  margin-top: $dp-spaces--lv3;
 }
 
 /* login form */

--- a/assets/scss/templates/_signup.scss
+++ b/assets/scss/templates/_signup.scss
@@ -8,7 +8,7 @@
   .main-panel {
     width: 525px;
     height: 100vh;
-    padding: $dp-spaces--lv7 $dp-spaces--lv6;
+    padding: $dp-spaces--lv6 $dp-spaces--lv8;
     background-color: $dp-color-white;
     overflow-y: auto;
 
@@ -35,7 +35,7 @@
     }
 
     h5 {
-      margin: $dp-spaces--lv10 $dp-spaces--lv0 $dp-spaces--lv2;
+      margin: $dp-spaces--lv5 $dp-spaces--lv0 $dp-spaces--lv1;
       font-family: $dp-font-family-proximanova;
       color: $dp-color-brown;
       font-weight: $dp-font-weight-bold;
@@ -61,6 +61,7 @@
 
     .content-legal {
       margin-top: $dp-spaces--lv4;
+      margin-bottom: $dp-spaces--lv7;
 
       p {
         font-size: $dp-font-size-rpgd;
@@ -68,9 +69,6 @@
       }
     }
 
-    footer {
-      padding-top: $dp-spaces--lv3;
-    }
   }
 
   .feature-panel {

--- a/assets/templates/signup.html
+++ b/assets/templates/signup.html
@@ -57,25 +57,24 @@
             </div>
           </div>
         </header><!-- header -->
-        <h5>Regístrate</h5>
-        <p class="content-subtitle">Crea una cuenta GRATIS hasta 500 Suscriptores.</p><!-- Title -->
-        <p class="content-subtitle">¿Ya tienes una cuenta? <a href="#" class="link--title" target="_blank">INGRESA</a></p>
+        <h5>EMAIL, AUTOMATION & DATA MARKETING</h5>
+        <p class="content-subtitle">Atrae, Convierte y Fideliza. Envíos ilimitados y gratis hasta 500 Suscriptores. ¿Ya tienes una cuenta? <a href="#" class="link--title" target="_blank">INGRESA</a></p><!-- Title -->
         <form class="signup-form">
           <fieldset>
             <legend>Datos personales</legend>
             <ul class="field-group">
               <li>
                 <ul class="field-group">
-                  <li class="field-item field-item--50 error">
+                  <li class="field-item field-item--50">
                     <label for="name">Nombre:</label>
-                    <input type="text" name="name" id="name" placeholder="Nombre">
+                    <input type="text" name="name" id="name">
                     <div class="wrapper-errors">
                       <p class="error-message">¡Ouch! Este campo está vacío</p>
                     </div>
                   </li>
-                  <li class="field-item field-item--50 error">
+                  <li class="field-item field-item--50">
                     <label for="lastname">Apellido:</label>
-                    <input type="text" name="lastname" id="lastname" placeholder="Apellido">
+                    <input type="text" name="lastname" id="lastname">
                     <div class="wrapper-errors">
                       <p class="error-message">¡Ouch! Este campo está vacío</p>
                     </div>
@@ -94,7 +93,7 @@
           <fieldset>
             <ul class="field-group">
               <legend>Usuario y contraseña</legend>
-              <li class="field-item error">
+              <li class="field-item">
                 <label for="email">Email:</label>
                 <input type="email" name="email" id="email" placeholder="Tu Email será tu nombre de usuario">
                 <div class="wrapper-errors">
@@ -106,9 +105,9 @@
                 <input type="password" name="password" id="password-field" placeholder="Escribe tu clave secreta">
                 <div class="wrapper-password">
                   <p class="password-message"><span class="waiting-message">8 caracteres como mínimo</span><span class="waiting-message">Un dígito</span></p>
-                  <p class="password-message"><span class="lack-message">8 caracteres como mínimo</span><span class="lack-message">Un dígito</span></p>
+                  <!-- <p class="password-message"><span class="lack-message">8 caracteres como mínimo</span><span class="lack-message">Un dígito</span></p>
                   <p class="password-message"><span class="complete-message">8 caracteres como mínimo</span><span class="complete-message">Un dígito</span></p>
-                  <p class="password-message"><span class="secure-message">¡Tu contraseña es segura!</span></p>
+                  <p class="password-message"><span class="secure-message">¡Tu contraseña es segura!</span></p> -->
                 </div><!-- the final container of message validations -->
               </li>
             </ul>
@@ -116,9 +115,9 @@
           <fieldset>
             <legend>Politica de privacidad y promociones</legend>
             <ul class="field-group">
-              <li class="field-item field-item__checkbox error">
+              <li class="field-item field-item__checkbox">
                 <input type="checkbox" name="acepto_politicas">
-                <span class="checkmark"></span><label for="acepto_politicas"> Acepto la <a class="link-green" href="#">Política de Privacidad</a> de Doppler.</label>
+                <span class="checkmark"></span><label for="acepto_politicas"> Acepto la <a href="#">Política de Privacidad</a> de Doppler.</label>
                 <div class="wrapper-errors">
                   <p class="error-message">¡Ouch! Este campo está vacío</p>
                 </div>
@@ -126,23 +125,21 @@
               <li class="field-item field-item__checkbox">
                 <input type="checkbox" name="acepto_promociones">
                 <span class="checkmark"></span>
-                <label for="acepto_promociones"> Acepto recibir las promociones de Doppler y sus aliados.</label>
+                <label for="acepto_promociones">Quiero recibir promociones de Doppler y sus aliados.</label>
               </li>
             </ul>
-            <button type="button" class="dp-button button--round button-medium primary-green">Crear cuenta</button>
+            <button type="button" class="dp-button button--round button-medium primary-green">CREA TU CUENTA GRATIS</button>
           </fieldset><!-- privacy policy and promotion -->
         </form><!-- form -->
         <div class="content-legal">
-          <p>Doppler te informa que los datos de carácter personal que nos proporciones al rellenar el presente formulario serán tratados por Making Sense LLC (Doppler) como responsable de esta web.</p>
+          <p>Doppler te informa que los datos de carácter personal que nos proporciones al rellenar el presente formulario serán tratados por Doppler LLC como responsable de esta web.</p>
           <p><strong>Finalidad:</strong> Darte de alta en nuestra plataforma y brindarte los servicios que nos requieras.</p>
           <p><strong>Legitimación:</strong> Consentimiento del interesado.</p>
           <p><strong>Destinatarios:</strong> Tus datos serán guardados por Doppler, Zoho como CRM, Digital Ocean, Cogeco Peer1 y Rackspace como empresas de hosting.</p>
-          <p><strong>Información adicional:</strong> En la <a href="#" class="link-green" target="_blank">Política de Privacidad</a> de Doppler encontrarás información adicional sobre la recopilación y el uso de su información personal por parte de
-            Doppler, incluida información sobre acceso, conservación, rectificación, eliminación, seguridad, transferencias transfronterizas y otros temas.</p>
+          <p><strong>Información adicional:</strong> En la <a href="#" target="_blank">Política de Privacidad</a> de Doppler encontrarás información adicional sobre la recopilación y el uso de su información personal por parte de Doppler, incluida información sobre acceso, conservación, rectificación, eliminación, seguridad, transferencias transfronterizas y otros temas.</p>
         </div><!-- legal content-->
-        <p class="content-promotion">Pst! si tienes un código promocional podrás ingresarlo al confirmar tu cuenta. <a href="#" class="link-green" target="_blank">HELP</a></p>
         <footer>
-          <small>© 2019 Doppler LLC. Todos los derechos reservados.</small>
+          <small>© 2019 Doppler LLC. Todos los derechos reservados. <a href="#" target="_blank">Política de Privacidad y Legales.</a></small>
         </footer><!-- footer -->
       </article>
       <section class="feature-panel">

--- a/assets/templates/signup.html
+++ b/assets/templates/signup.html
@@ -57,7 +57,7 @@
             </div>
           </div>
         </header><!-- header -->
-        <h5>EMAIL, AUTOMATION & DATA MARKETING</h5>
+        <h5>email, automation & data marketing</h5>
         <p class="content-subtitle">Atrae, Convierte y Fideliza. Envíos ilimitados y gratis hasta 500 Suscriptores. ¿Ya tienes una cuenta? <a href="#" class="link--title" target="_blank">INGRESA</a></p><!-- Title -->
         <form class="signup-form">
           <fieldset>
@@ -128,7 +128,7 @@
                 <label for="acepto_promociones">Quiero recibir promociones de Doppler y sus aliados.</label>
               </li>
             </ul>
-            <button type="button" class="dp-button button--round button-medium primary-green">CREA TU CUENTA GRATIS</button>
+            <button type="button" class="dp-button button--round button-medium primary-green">crea tu cuenta gratis</button>
           </fieldset><!-- privacy policy and promotion -->
         </form><!-- form -->
         <div class="content-legal">


### PR DESCRIPTION
- Adjust margins to see the "SIGN UP FOR FREE" button on a 650px high screen.
- Eliminate unnecessary link - green classes.
- Place the final contents of Signup.
- Eliminate unnecessary placeholders as marked by the final content.

https://cdn.fromdoppler.com/doppler-ui-library/build185/signup.html

![screen_650](https://user-images.githubusercontent.com/46735526/55656153-7175c800-57cc-11e9-8210-476619712927.jpg)
