### PR TITLE
DBR-213 - General form messages

### DIFF
--- a/assets/scss/core/_base.scss
+++ b/assets/scss/core/_base.scss
@@ -246,11 +246,19 @@ input[type="tel"] {
 
   .wrapper-errors {
     display: inline-block;
+    margin: $dp-spaces--lv0;
+    color: $dp-color-red;
+    font-size: $dp-sizing--lvl2;
 
-    .error-message {
-      margin: $dp-spaces--lv0;
+    a {
       color: $dp-color-red;
+      text-decoration: underline;
+    }
+
+    p {
+      margin: $dp-spaces--lv0;
       font-size: $dp-sizing--lvl2;
+      line-height: $dp-spaces--lv3;
     }
   }
   /* animation to show the errors (optional) */
@@ -337,12 +345,4 @@ input[type="tel"] {
   }
   /* Class to indicate that password is secure */
 }
-/* Classes of messages to verify the password */
-.unexpected-message {
-  font-family: $dp-font-family;
-  margin: $dp-spaces--lv0;
-  color: $dp-color-red;
-  font-size: $dp-sizing--lvl2;
-  padding: $dp-spaces--lv2 $dp-spaces--lv0;
-}
-/* Classes of Unexpected message */
+

--- a/assets/scss/core/_base.scss
+++ b/assets/scss/core/_base.scss
@@ -236,6 +236,10 @@ input[type="tel"] {
   display: none;
 }
 
+.form-message {
+  margin-bottom: $dp-spaces--lv2;
+}
+
 .error {
   .checkmark,
   input,

--- a/assets/scss/core/_base.scss
+++ b/assets/scss/core/_base.scss
@@ -238,6 +238,7 @@ input[type="tel"] {
 
 .form-message {
   margin-bottom: $dp-spaces--lv2;
+  font-family: $dp-font-family;
 }
 
 .error {

--- a/assets/scss/core/_base.scss
+++ b/assets/scss/core/_base.scss
@@ -238,7 +238,6 @@ input[type="tel"] {
 
 .form-message {
   margin-bottom: $dp-spaces--lv2;
-  font-family: $dp-font-family;
 }
 
 .error {
@@ -254,6 +253,7 @@ input[type="tel"] {
     margin: $dp-spaces--lv0;
     color: $dp-color-red;
     font-size: $dp-sizing--lvl2;
+    font-family: $dp-font-family-proximanova;
 
     a {
       color: $dp-color-red;
@@ -264,6 +264,7 @@ input[type="tel"] {
       margin: $dp-spaces--lv0;
       font-size: $dp-sizing--lvl2;
       line-height: $dp-spaces--lv3;
+      font-family: $dp-font-family-proximanova;
     }
   }
   /* animation to show the errors (optional) */

--- a/assets/templates/forgot-password.html
+++ b/assets/templates/forgot-password.html
@@ -75,7 +75,7 @@
                 <label for="email">Email:</label>
                 <input type="email" name="email" id="email" placeholder="¡Psst! Es tu Email.">
                 <div class="wrapper-errors">
-                  <p class="error-message">¡Ouch! Este campo está vacío</p>
+                  <p>¡Ouch! Este campo está vacío</p>
                 </div>
               </li>
             </ul>

--- a/assets/templates/login.html
+++ b/assets/templates/login.html
@@ -67,6 +67,12 @@
         <p class="content-subtitle">Disfruta los beneficios del Email Marketing.</p><!-- Title -->
         <p class="content-subtitle">¿Aún no tienes una cuenta? <a href="#" class="link--title" target="_blank">REGÍSTRATE GRATIS</a></p>
         <form class="login-form">
+          <div class="form-message error">
+            <div class="wrapper-errors">
+              <p>Espera un segundo. Aún no has activado tu cuenta.</p>
+              <p><a href="#">Reenviar el Email de Activación.</a></p>
+            </div>
+          </div>
           <fieldset>
             <ul class="field-group">
               <legend>Usuario y contraseña</legend>

--- a/assets/templates/login.html
+++ b/assets/templates/login.html
@@ -80,14 +80,14 @@
                 <label for="email">Nombre de Usuario:</label>
                 <input type="email" name="email" id="email" placeholder="¡Psst! Es tu Email.">
                 <div class="wrapper-errors">
-                  <p class="error-message">¡Ouch! Este campo está vacío</p>
+                  <p>¡Ouch! Este campo está vacío</p>
                 </div>
               </li>
               <li class="field-item">
                 <label for="password">Contraseña: <a toggle="#password-field" class="ms-icon icon-view show-hide"> <span class="content-eye">Mostrar</a></label>
                 <input type="password" name="password" id="password-field" placeholder="Escribe tu clave secreta">
                 <div class="wrapper-errors">
-                  <p class="error-message">¡Ouch! Este campo está vacío</p>
+                  <p>¡Ouch! Este campo está vacío</p>
                 </div>
               </li>
             </ul>

--- a/assets/templates/modal.html
+++ b/assets/templates/modal.html
@@ -86,7 +86,7 @@
                   <option value="">75001-100000</option>
                 </select>
                 <div class="wrapper-errors bounceIn">
-                  <p class="error-message">¡Ouch! Este campo está vacío</p>
+                  <p>¡Ouch! Este campo está vacío</p>
                 </div>
                 <!--error-messages-->
               </li><!-- field-item -->
@@ -94,8 +94,8 @@
                 <label for="message">Mensaje </label>
                 <textarea id="message" name="message" placeholder="Tu mensage"></textarea>
                 <div class="wrapper-errors bounceIn">
-                  <p class="error-message">¡Ouch! Este campo está vacío</p>
-                  <span class="error-message">¡Ouch! Este campo está vacío</span>
+                  <p>¡Ouch! Este campo está vacío</p>
+                  <span>¡Ouch! Este campo está vacío</span>
                 </div><!-- error-messages -->
               </li><!-- field-item -->
             </ul><!-- field-group -->

--- a/assets/templates/signup.html
+++ b/assets/templates/signup.html
@@ -75,14 +75,14 @@
                     <label for="name">Nombre:</label>
                     <input type="text" name="name" id="name">
                     <div class="wrapper-errors">
-                      <p class="error-message">¡Ouch! Este campo está vacío</p>
+                      <p>¡Ouch! Este campo está vacío</p>
                     </div>
                   </li>
                   <li class="field-item field-item--50">
                     <label for="lastname">Apellido:</label>
                     <input type="text" name="lastname" id="lastname">
                     <div class="wrapper-errors">
-                      <p class="error-message">¡Ouch! Este campo está vacío</p>
+                      <p>¡Ouch! Este campo está vacío</p>
                     </div>
                   </li>
                 </ul>
@@ -91,7 +91,7 @@
                 <label for="phone">Teléfono:</label>
                 <input type="tel" name="phone" id="phone-input" placeholder="9 11 2345-6789" class="phone-number">
                 <div class="wrapper-errors">
-                  <p class="error-message error-phone-number">¡Ouch! Este campo está vacío</p>
+                  <p class="error-phone-number">¡Ouch! Este campo está vacío</p>
                 </div>
               </li>
             </ul>
@@ -103,7 +103,7 @@
                 <label for="email">Email:</label>
                 <input type="email" name="email" id="email" placeholder="Tu Email será tu nombre de usuario">
                 <div class="wrapper-errors">
-                  <p class="error-message">¡Ouch! Este campo está vacío</p>
+                  <p>¡Ouch! Este campo está vacío</p>
                 </div>
               </li>
               <li class="field-item">
@@ -125,7 +125,7 @@
                 <input type="checkbox" name="acepto_politicas">
                 <span class="checkmark"></span><label for="acepto_politicas"> Acepto la <a href="#">Política de Privacidad</a> de Doppler.</label>
                 <div class="wrapper-errors">
-                  <p class="error-message">¡Ouch! Este campo está vacío</p>
+                  <p>¡Ouch! Este campo está vacío</p>
                 </div>
               </li>
               <li class="field-item field-item__checkbox">

--- a/assets/templates/signup.html
+++ b/assets/templates/signup.html
@@ -66,6 +66,11 @@
         <h5>email, automation & data marketing</h5>
         <p class="content-subtitle">Atrae, Convierte y Fideliza. Envíos ilimitados y gratis hasta 500 Suscriptores. ¿Ya tienes una cuenta? <a href="#" class="link--title" target="_blank">INGRESA</a></p><!-- Title -->
         <form class="signup-form">
+          <div class="form-message error">
+              <div class="wrapper-errors">
+                <span>¡Ouch! Mensaje inesperado</span>
+              </div>
+            </div>
           <fieldset>
             <legend>Datos personales</legend>
             <ul class="field-group">
@@ -135,7 +140,6 @@
               </li>
             </ul>
           </fieldset><!-- privacy policy and promotion -->
-          <div class="unexpected-message"><span>¡Ouch! Mensaje inesperado</span></div>
           <button type="button" class="dp-button button--round button-medium primary-green">crea tu cuenta gratis</button>
         </form><!-- form -->
         <div class="content-legal">


### PR DESCRIPTION
Hey team! I am touching SCSS hehe!

The idea is unifying general form errors and field errors, and in both of them support basic HTML: p, span, strong, em, links, etc. 

By the moment, li is not being supported, because I do not need it yet.

Could you review it?

Thanks @GusBaamonde for your help!

@mvillaseco, @cbernat, @IgnacioRodrigues, @damianmuti 

You can review it in (in the mockups the font is wrong, in build 224 it is fixed)

* https://cdn.fromdoppler.com/doppler-ui-library/build224/signup.html
    
    ![image](https://user-images.githubusercontent.com/1157864/56924625-bdeab580-6aa3-11e9-824d-402b535ed6c8.png)

* https://cdn.fromdoppler.com/doppler-ui-library/build224/login.html

    ![image](https://user-images.githubusercontent.com/1157864/56924652-d35fdf80-6aa3-11e9-9866-8caaa36826a1.png)


