### PR TITLE
fix: links should inherit font-size

### DIFF
--- a/assets/scss/templates/_signup.scss
+++ b/assets/scss/templates/_signup.scss
@@ -170,7 +170,6 @@
 
 .link--title {
   font-weight: $dp-font-weight-bold;
-  font-size: $dp-sizing--lvl2;
   text-transform: uppercase;
   font-style: normal;
 }


### PR DESCRIPTION
For the login, signup, and forgot password pages, register/signup links after the main header should inherit their font-size.