### PR TITLE
fix: issues with line-height and font declaration specificity

### DIFF
--- a/assets/scss/core/_typography.scss
+++ b/assets/scss/core/_typography.scss
@@ -62,7 +62,7 @@ strong {
 
 p {
   font-size: $dp-sizing--lvl3;
-  line-height: $dp-font-lineheight;
+  line-height: #{$dp-font-lineheight / $dp-sizing--lvl3}; // Unitless equivalent to ems
 }
 
 small {

--- a/assets/scss/core/_typography.scss
+++ b/assets/scss/core/_typography.scss
@@ -1,6 +1,7 @@
 @import "./settings";
 
 body {
+  font-family: $dp-font-family;
   color: $dp-color-grey;
 }
 
@@ -60,7 +61,6 @@ strong {
 }
 
 p {
-  font: $dp-font;
   font-size: $dp-sizing--lvl3;
   line-height: $dp-font-lineheight;
 }


### PR DESCRIPTION
Despite fixing this issue, I've added a small improvement to prevent these kind of issues in the future because of specificity with the `font` declaration.