### PR TITLE
refactor: dropdowns now are accessible with keyboard

### DIFF
--- a/assets/js/MenuItemLinks.js
+++ b/assets/js/MenuItemLinks.js
@@ -1,0 +1,160 @@
+/*
+*   This content is licensed according to the W3C Software License at
+*   https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+*
+*   File:   MenuItemLinks.js
+*
+*   Desc:   Popup Menu Menuitem widget that implements ARIA Authoring Practices
+*/
+
+/*
+*   @constructor MenuItemLinks
+*
+*   @desc
+*       Wrapper object for a simple menu item in a popup menu
+*
+*   @param domNode
+*       The DOM element node that serves as the menu item container.
+*       The menuObj PopupMenu is responsible for checking that it has
+*       requisite metadata, e.g. role="menuitem".
+*
+*   @param menuObj
+*       The object that is a wrapper for the PopupMenu DOM element that
+*       contains the menu item DOM element. See PopupMenu.js
+*/
+var MenuItemLinks = function (domNode, menuObj) {
+
+  this.domNode = domNode;
+  this.menu = menuObj;
+
+  this.keyCode = Object.freeze({
+    'TAB': 9,
+    'RETURN': 13,
+    'ESC': 27,
+    'SPACE': 32,
+    'PAGEUP': 33,
+    'PAGEDOWN': 34,
+    'END': 35,
+    'HOME': 36,
+    'LEFT': 37,
+    'UP': 38,
+    'RIGHT': 39,
+    'DOWN': 40
+  });
+};
+
+MenuItemLinks.prototype.init = function () {
+  this.domNode.tabIndex = -1;
+
+  if (!this.domNode.getAttribute('role')) {
+    this.domNode.setAttribute('role', 'menuitem');
+  }
+
+  this.domNode.addEventListener('keydown',    this.handleKeydown.bind(this));
+  this.domNode.addEventListener('click',      this.handleClick.bind(this));
+  this.domNode.addEventListener('focus',      this.handleFocus.bind(this));
+  this.domNode.addEventListener('blur',       this.handleBlur.bind(this));
+  this.domNode.addEventListener('mouseover',  this.handleMouseover.bind(this));
+  this.domNode.addEventListener('mouseout',   this.handleMouseout.bind(this));
+
+};
+
+/* EVENT HANDLERS */
+
+MenuItemLinks.prototype.handleKeydown = function (event) {
+  var flag = false,
+    char = event.key;
+
+  function isPrintableCharacter (str) {
+    return str.length === 1 && str.match(/\S/);
+  }
+
+  if (event.ctrlKey || event.altKey  || event.metaKey || (event.keyCode === this.keyCode.SPACE) || (event.keyCode === this.keyCode.RETURN)) {
+    return;
+  }
+
+  if (event.shiftKey) {
+    if (isPrintableCharacter(char)) {
+      this.menu.setFocusByFirstCharacter(this, char);
+      flag = true;
+    }
+
+    if (event.keyCode === this.keyCode.TAB) {
+      this.menu.setFocusToController();
+      this.menu.close(true);
+    }
+  }
+  else {
+    switch (event.keyCode) {
+
+      case this.keyCode.ESC:
+        this.menu.setFocusToController();
+        this.menu.close(true);
+        flag = true;
+        break;
+
+      case this.keyCode.UP:
+        this.menu.setFocusToPreviousItem(this);
+        flag = true;
+        break;
+
+      case this.keyCode.DOWN:
+        this.menu.setFocusToNextItem(this);
+        flag = true;
+        break;
+
+      case this.keyCode.HOME:
+      case this.keyCode.PAGEUP:
+        this.menu.setFocusToFirstItem();
+        flag = true;
+        break;
+
+      case this.keyCode.END:
+      case this.keyCode.PAGEDOWN:
+        this.menu.setFocusToLastItem();
+        flag = true;
+        break;
+
+      case this.keyCode.TAB:
+        this.menu.setFocusToController();
+        this.menu.close(true);
+        break;
+
+      default:
+        if (isPrintableCharacter(char)) {
+          this.menu.setFocusByFirstCharacter(this, char);
+        }
+        break;
+    }
+  }
+
+  if (flag) {
+    event.stopPropagation();
+    event.preventDefault();
+  }
+};
+
+MenuItemLinks.prototype.handleClick = function (event) {
+  this.menu.setFocusToController();
+  this.menu.close(true);
+};
+
+MenuItemLinks.prototype.handleFocus = function (event) {
+  this.menu.hasFocus = true;
+};
+
+MenuItemLinks.prototype.handleBlur = function (event) {
+  this.menu.hasFocus = false;
+  setTimeout(this.menu.close.bind(this.menu, false), 300);
+};
+
+MenuItemLinks.prototype.handleMouseover = function (event) {
+  this.menu.hasHover = true;
+  this.menu.open();
+
+};
+
+MenuItemLinks.prototype.handleMouseout = function (event) {
+  this.menu.hasHover = false;
+  setTimeout(this.menu.close.bind(this.menu, false), 300);
+};

--- a/assets/js/PopupMenuLinks.js
+++ b/assets/js/PopupMenuLinks.js
@@ -1,0 +1,236 @@
+/*
+*   This content is licensed according to the W3C Software License at
+*   https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+*
+*   File:   PopupMenuLinks.js
+*
+*   Desc:   Popup menu Links widget that implements ARIA Authoring Practices
+*/
+
+/*
+*   @constructor PopupMenuLinks
+*
+*   @desc
+*       Wrapper object for a simple popup menu (without nested submenus)
+*
+*   @param domNode
+*       The DOM element node that serves as the popup menu container. Each
+*       child element of domNode that represents a menuitem must have a
+*       'role' attribute with value 'menuitem'.
+*
+*   @param controllerObj
+*       The object that is a wrapper for the DOM element that controls the
+*       menu, e.g. a button element, with an 'aria-controls' attribute that
+*       references this menu's domNode. See MenuButton.js
+*
+*       The controller object is expected to have the following properties:
+*       1. domNode: The controller object's DOM element node, needed for
+*          retrieving positioning information.
+*       2. hasHover: boolean that indicates whether the controller object's
+*          domNode has responded to a mouseover event with no subsequent
+*          mouseout event having occurred.
+*/
+var PopupMenuLinks = function (domNode, controllerObj) {
+  var elementChildren,
+    msgPrefix = 'PopupMenuLinks constructor argument domNode ';
+
+  // Check whether domNode is a DOM element
+  if (!domNode instanceof Element) {
+    throw new TypeError(msgPrefix + 'is not a DOM Element.');
+  }
+
+  // Check whether domNode has child elements
+  if (domNode.childElementCount === 0) {
+    throw new Error(msgPrefix + 'has no element children.');
+  }
+
+  // Check whether domNode descendant elements have A elements
+  var childElement = domNode.firstElementChild;
+  while (childElement) {
+    var menuitem = childElement.firstElementChild;
+    if (menuitem && menuitem.tagName !== 'A') {
+      throw new Error(msgPrefix + 'has descendant elements that are not A elements.');
+    }
+    childElement = childElement.nextElementSibling;
+  }
+
+  this.domNode = domNode;
+  this.controller = controllerObj;
+
+  this.menuitems  = [];      // see PopupMenuLinks init method
+  this.firstChars = [];      // see PopupMenuLinks init method
+
+  this.firstItem  = null;    // see PopupMenuLinks init method
+  this.lastItem   = null;    // see PopupMenuLinks init method
+
+  this.hasFocus   = false;   // see MenuItemLinks handleFocus, handleBlur
+  this.hasHover   = false;   // see PopupMenuLinks handleMouseover, handleMouseout
+};
+
+/*
+*   @method PopupMenuLinks.prototype.init
+*
+*   @desc
+*       Add domNode event listeners for mouseover and mouseout. Traverse
+*       domNode children to configure each menuitem and populate menuitems
+*       array. Initialize firstItem and lastItem properties.
+*/
+PopupMenuLinks.prototype.init = function () {
+  var childElement, menuElement, menuItem, textContent, numItems, label;
+
+  // Configure the domNode itself
+  this.domNode.tabIndex = -1;
+
+  this.domNode.setAttribute('role', 'menu');
+
+  if (!this.domNode.getAttribute('aria-labelledby') && !this.domNode.getAttribute('aria-label') && !this.domNode.getAttribute('title')) {
+    label = this.controller.domNode.innerHTML;
+    this.domNode.setAttribute('aria-label', label);
+  }
+
+  this.domNode.addEventListener('mouseover', this.handleMouseover.bind(this));
+  this.domNode.addEventListener('mouseout',  this.handleMouseout.bind(this));
+
+  // Traverse the element children of domNode: configure each with
+  // menuitem role behavior and store reference in menuitems array.
+  childElement = this.domNode.firstElementChild;
+
+  while (childElement) {
+    menuElement = childElement.firstElementChild;
+
+    if (menuElement && menuElement.tagName === 'A') {
+      menuItem = new MenuItemLinks(menuElement, this);
+      menuItem.init();
+      this.menuitems.push(menuItem);
+      textContent = menuElement.textContent.trim();
+      this.firstChars.push(textContent.substring(0, 1).toLowerCase());
+    }
+    childElement = childElement.nextElementSibling;
+  }
+
+  // Use populated menuitems array to initialize firstItem and lastItem.
+  numItems = this.menuitems.length;
+  if (numItems > 0) {
+    this.firstItem = this.menuitems[0];
+    this.lastItem  = this.menuitems[numItems - 1];
+  }
+};
+
+/* EVENT HANDLERS */
+
+PopupMenuLinks.prototype.handleMouseover = function (event) {
+  this.hasHover = true;
+};
+
+PopupMenuLinks.prototype.handleMouseout = function (event) {
+  this.hasHover = false;
+  setTimeout(this.close.bind(this, false), 300);
+};
+
+/* FOCUS MANAGEMENT METHODS */
+
+PopupMenuLinks.prototype.setFocusToController = function (command) {
+  if (typeof command !== 'string') {
+    command = '';
+  }
+
+  if (command === 'previous') {
+    this.controller.menubar.setFocusToPreviousItem(this.controller);
+  }
+  else {
+    if (command === 'next') {
+      this.controller.menubar.setFocusToNextItem(this.controller);
+    }
+    else {
+      this.controller.domNode.focus();
+    }
+  }
+};
+
+PopupMenuLinks.prototype.setFocusToFirstItem = function () {
+  this.firstItem.domNode.focus();
+};
+
+PopupMenuLinks.prototype.setFocusToLastItem = function () {
+  this.lastItem.domNode.focus();
+};
+
+PopupMenuLinks.prototype.setFocusToPreviousItem = function (currentItem) {
+  var index;
+
+  if (currentItem === this.firstItem) {
+    this.lastItem.domNode.focus();
+  }
+  else {
+    index = this.menuitems.indexOf(currentItem);
+    this.menuitems[index - 1].domNode.focus();
+  }
+};
+
+PopupMenuLinks.prototype.setFocusToNextItem = function (currentItem) {
+  var index;
+
+  if (currentItem === this.lastItem) {
+    this.firstItem.domNode.focus();
+  }
+  else {
+    index = this.menuitems.indexOf(currentItem);
+    this.menuitems[index + 1].domNode.focus();
+  }
+};
+
+PopupMenuLinks.prototype.setFocusByFirstCharacter = function (currentItem, char) {
+  var start, index, char = char.toLowerCase();
+
+  // Get start index for search based on position of currentItem
+  start = this.menuitems.indexOf(currentItem) + 1;
+  if (start === this.menuitems.length) {
+    start = 0;
+  }
+
+  // Check remaining slots in the menu
+  index = this.getIndexFirstChars(start, char);
+
+  // If not found in remaining slots, check from beginning
+  if (index === -1) {
+    index = this.getIndexFirstChars(0, char);
+  }
+
+  // If match was found...
+  if (index > -1) {
+    this.menuitems[index].domNode.focus();
+  }
+};
+
+PopupMenuLinks.prototype.getIndexFirstChars = function (startIndex, char) {
+  for (var i = startIndex; i < this.firstChars.length; i++) {
+    if (char === this.firstChars[i]) {
+      return i;
+    }
+  }
+  return -1;
+};
+
+/* MENU DISPLAY METHODS */
+
+PopupMenuLinks.prototype.open = function () {
+  // get position and bounding rectangle of controller object's DOM node
+  var rect = this.controller.domNode.getBoundingClientRect();
+
+  // set CSS properties
+  this.domNode.style.display = 'block';
+  this.domNode.style.position = 'absolute';
+  this.domNode.style.top  = rect.height + 'px';
+  this.domNode.style.left = '0px';
+
+  // set aria-expanded attribute
+  this.controller.domNode.setAttribute('aria-expanded', 'true');
+};
+
+PopupMenuLinks.prototype.close = function (force) {
+
+  if (force || (!this.hasFocus && !this.hasHover && !this.controller.hasHover)) {
+    this.domNode.style.display = 'none';
+    this.controller.domNode.removeAttribute('aria-expanded');
+  }
+};

--- a/assets/js/dropdown.js
+++ b/assets/js/dropdown.js
@@ -1,0 +1,136 @@
+/*
+*   This content is licensed according to the W3C Software License at
+*   https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+*
+*   File:   Menubutton.js
+*
+*   Desc:   Menubutton Menuitem widget that implements ARIA Authoring Practices
+*/
+
+/*
+*   @constructor MenubuttonItem
+*
+*   @desc
+*       Object that configures menu item elements by setting tabIndex
+*       and registering itself to handle pertinent events.
+*
+*       While menuitem elements handle many keydown events, as well as
+*       focus and blur events, they do not maintain any state variables,
+*       delegating those responsibilities to its associated menu object.
+*
+*       Consequently, it is only necessary to create one instance of
+*       MenubuttonItem from within the menu object; its configure method
+*       can then be called on each menuitem element.
+*
+*   @param domNode
+*       The DOM element node that serves as the menu item container.
+*       The menuObj PopupMenu is responsible for checking that it has
+*       requisite metadata, e.g. role="menuitem".
+*
+*/
+var Menubutton = function (domNode) {
+
+  this.domNode   = domNode;
+  this.popupMenu = false;
+
+  this.hasFocus = false;
+  this.hasHover = false;
+
+  this.keyCode = Object.freeze({
+    'TAB': 9,
+    'RETURN': 13,
+    'ESC': 27,
+    'SPACE': 32,
+    'PAGEUP': 33,
+    'PAGEDOWN': 34,
+    'END': 35,
+    'HOME': 36,
+    'LEFT': 37,
+    'UP': 38,
+    'RIGHT': 39,
+    'DOWN': 40
+  });
+};
+
+Menubutton.prototype.init = function () {
+
+  this.domNode.setAttribute('aria-haspopup', 'true');
+
+  this.domNode.addEventListener('keydown',    this.handleKeydown.bind(this));
+  this.domNode.addEventListener('click',      this.handleClick.bind(this));
+  this.domNode.addEventListener('focus',      this.handleFocus.bind(this));
+  this.domNode.addEventListener('blur',       this.handleBlur.bind(this));
+  // Commented the following listeners since we are going to use this dropdown component only on click/keydown events
+  //this.domNode.addEventListener('mouseover',  this.handleMouseover.bind(this));
+  //this.domNode.addEventListener('mouseout',   this.handleMouseout.bind(this));
+
+  // initialize pop up menus
+
+  var popupMenu = document.getElementById(this.domNode.getAttribute('aria-controls'));
+
+  if (popupMenu) {
+    this.popupMenu = new PopupMenuLinks(popupMenu, this);
+    this.popupMenu.init();
+  }
+
+};
+
+Menubutton.prototype.handleKeydown = function (event) {
+  var flag = false;
+
+  switch (event.keyCode) {
+    case this.keyCode.SPACE:
+    case this.keyCode.RETURN:
+    case this.keyCode.DOWN:
+      if (this.popupMenu) {
+        this.popupMenu.open();
+        this.popupMenu.setFocusToFirstItem();
+      }
+      flag = true;
+      break;
+
+    case this.keyCode.UP:
+      if (this.popupMenu) {
+        this.popupMenu.open();
+        this.popupMenu.setFocusToLastItem();
+        flag = true;
+      }
+      break;
+
+    default:
+      break;
+  }
+
+  if (flag) {
+    event.stopPropagation();
+    event.preventDefault();
+  }
+};
+
+Menubutton.prototype.handleClick = function (event) {
+  if (this.domNode.getAttribute('aria-expanded') == 'true') {
+    this.popupMenu.close(true);
+  }
+  else {
+    this.popupMenu.open();
+    this.popupMenu.setFocusToFirstItem();
+  }
+};
+
+Menubutton.prototype.handleFocus = function (event) {
+  this.popupMenu.hasFocus = true;
+};
+
+Menubutton.prototype.handleBlur = function (event) {
+  this.popupMenu.hasFocus = false;
+};
+
+Menubutton.prototype.handleMouseover = function (event) {
+  this.hasHover = true;
+  this.popupMenu.open();
+};
+
+Menubutton.prototype.handleMouseout = function (event) {
+  this.hasHover = false;
+  setTimeout(this.popupMenu.close.bind(this.popupMenu, false), 300);
+};

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -33,20 +33,10 @@ $("body").on('click', '.close-user--menu', function() {
   $('.user-menu').removeClass('open');
 });
 
-$("body").on('click', '.language-selector .lang-option', function() {
-  $(this).parents('.language-selector').toggleClass('is-open');
-});
-
 $(document).on('mouseup', function(e) {
   var menu = $(".user-menu");
-  var languageSelector = $(".language-selector");
-
   if (!menu.is(e.target) && menu.has(e.target).length === 0) {
     menu.removeClass('open');
-  }
-
-  if (!languageSelector.is(e.target) && languageSelector.has(e.target).length === 0) {
-    $('.language-selector').removeClass('is-open');
   }
 });
 

--- a/assets/scss/modules/_dropdown.scss
+++ b/assets/scss/modules/_dropdown.scss
@@ -1,1 +1,35 @@
 
+.dp-c-dropdown {
+  position: relative;
+
+  button {
+    display: block;
+    text-align: center;
+    text-decoration: none;
+  }
+
+  ul[role="menu"] {
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    list-style: none;
+    display: none;
+
+    li {
+      margin: 0;
+      padding: 0;
+    }
+
+    a[role="menuitem"],
+    a[role="menuitem"]:visited {
+      display: block;
+      text-decoration: none;
+    }
+
+    a[role="menuitem"]:focus,
+    a[role="menuitem"]:hover {
+      //color: white;
+    }
+  }
+}
+

--- a/assets/scss/modules/_language.scss
+++ b/assets/scss/modules/_language.scss
@@ -3,21 +3,14 @@ Language selector
 */
 
 .language-selector {
-  position: relative;
   height: 34px;
   width: 63px;
-  overflow: hidden;
   margin-bottom: -10px;
   font-family: $dp-font-family;
-
-  &.is-open {
-    overflow: visible;
-  }
 
   button,
   a {
     appearance: none;
-    position: relative;
     line-height: 20px;
     padding: 7px 13px 7px 35px;
     color: $dp-color-darkgrey;
@@ -26,9 +19,8 @@ Language selector
     text-align: right;
     background-repeat: no-repeat;
     background-position: 12px center;
-    outline: 0;
+    border-radius: 3px;
     text-decoration: none;
-    display: block;
 
     &.lang--es {
       background-image: url(../img/flag--spanish.svg);
@@ -38,41 +30,28 @@ Language selector
     }
   }
 
-  .lang-option {
-    width: 63px;
-    height: 34px;
+  a[role="menuitem"] {
+    outline: 0;
+    box-shadow: 0 0 0 1px $dp-color-darkyellow, 0 0 0 2px rgba(0,0,0,.1);
 
-    &.option--selector {
-      button,
-      a {
-        &:after {
-          content: '';
-          width: 0;
-          height: 0;
-          position: absolute;
-          border-top: 5px solid $dp-color-darkgrey;
-          border-right: 5px solid transparent;
-          border-left: 5px solid transparent;
-          top: 50%;
-          transform: translateY(-50%);
-          right: 0;
-        }
-      }
+    &:hover,
+    &:focus {
+      background-color: $dp-color-ghostwhite;
     }
+  }
 
-    &:not(.option--selector) {
-      button,
-      a {
-        position: absolute;
-        top: 36px;
-        border-radius: $dp-border-radius;
-        box-shadow: 0 0 0 1px $dp-color-yellow, 0 0 0 2px rgba(0,0,0,.1);
-        z-index: 5;
-
-        &:hover {
-          background-color: #f2f1e9;
-        }
-      }
+  button {
+    &:after {
+      content: '';
+      width: 0;
+      height: 0;
+      position: absolute;
+      border-top: 4px solid $dp-color-darkgrey;
+      border-right: 4px solid transparent;
+      border-left: 4px solid transparent;
+      top: 50%;
+      transform: translateY(-50%);
+      right: 3px;
     }
   }
 }

--- a/assets/templates/forgot-password.html
+++ b/assets/templates/forgot-password.html
@@ -50,17 +50,17 @@
     <article class="main-panel">
       <header>
         <h1 class="logo-doppler-new"><a href="#">Doppler</a></h1>
-        <div class="language-selector">
-          <div class="lang-option option--selector">
-            <button class="lang--es">
-              ES
-            </button>
-          </div>
-          <div class="lang-option">
-            <a href="#" class="lang--en">
-              EN
-            </a>
-          </div>
+        <div class="dp-c-dropdown language-selector">
+          <button class="lang--es" id="menubutton" aria-haspopup="true" aria-controls="menu2">
+            ES
+          </button>
+          <ul id="menu2" role="menu" aria-labelledby="menubutton">
+            <li role="none">
+              <a role="menuitem" href="#" class="lang--en">
+                EN
+              </a>
+            </li>
+          </ul>
         </div>
       </header><!-- header -->
       <h5>¿NO RECUERDAS TU CONTRASEÑA?</h5>
@@ -124,6 +124,12 @@
   <!-- build:js:dist js/app.js -->
   <script src="./js/main.js"></script>
   <!-- /build -->
+  <script type="text/javascript">
+    window.onload=function() {
+    var menubutton = new Menubutton(document.getElementById('menubutton'));
+    menubutton.init();
+    }
+  </script>
 </body>
 
 </html>

--- a/assets/templates/login.html
+++ b/assets/templates/login.html
@@ -50,17 +50,17 @@
       <article class="main-panel">
         <header>
           <h1 class="logo-doppler-new"><a href="#">Doppler</a></h1>
-          <div class="language-selector">
-            <div class="lang-option option--selector">
-              <button class="lang--es">
-                ES
-              </button>
-            </div>
-            <div class="lang-option">
-              <a href="#" class="lang--en">
-                EN
-              </a>
-            </div>
+          <div class="dp-c-dropdown language-selector">
+            <button class="lang--es" id="menubutton" aria-haspopup="true" aria-controls="menu2">
+              ES
+            </button>
+            <ul id="menu2" role="menu" aria-labelledby="menubutton">
+              <li role="none">
+                <a role="menuitem" href="#" class="lang--en">
+                  EN
+                </a>
+              </li>
+            </ul>
           </div>
         </header><!-- header -->
         <h5>INGRESA A DOPPLER</h5>
@@ -115,6 +115,12 @@
     <!-- build:js:dist js/app.js -->
     <script src="./js/main.js"></script>
     <!-- /build -->
+    <script type="text/javascript">
+      window.onload=function() {
+      var menubutton = new Menubutton(document.getElementById('menubutton'));
+      menubutton.init();
+      }
+    </script>
   </body>
 
 </html>

--- a/assets/templates/signup.html
+++ b/assets/templates/signup.html
@@ -50,17 +50,17 @@
       <article class="main-panel">
         <header>
           <h1 class="logo-doppler-new"><a href="#">Doppler</a></h1>
-          <div class="language-selector">
-            <div class="lang-option option--selector">
-              <button class="lang--es">
-                ES
-              </button>
-            </div>
-            <div class="lang-option">
-              <a href="#" class="lang--en">
-                EN
-              </a>
-            </div>
+          <div class="dp-c-dropdown language-selector">
+            <button class="lang--es" id="menubutton" aria-haspopup="true" aria-controls="menu2">
+              ES
+            </button>
+            <ul id="menu2" role="menu" aria-labelledby="menubutton">
+              <li role="none">
+                <a role="menuitem" href="#" class="lang--en">
+                  EN
+                </a>
+              </li>
+            </ul>
           </div>
         </header><!-- header -->
         <h5>email, automation & data marketing</h5>
@@ -237,6 +237,12 @@
 
     </script>
     <!-- /build -->
+    <script type="text/javascript">
+      window.onload=function() {
+      var menubutton = new Menubutton(document.getElementById('menubutton'));
+      menubutton.init();
+      }
+    </script>
   </body>
 
 </html>


### PR DESCRIPTION
One improvement that we've detected on the login/signup/forgot-password pages was that those pages are not keyboard accessible.
What we've ended up deciding to do was to refactor what we needed for keyboard accessibility to work, including dropdown menus.
Instead of creating something from scratch, I've checked what W3C says about dropdown menus and, to our fortune, they provide some javascript+html+css standalone modules for this to properly work, so this PR is based on that.

![image](https://user-images.githubusercontent.com/3520460/58582168-88aec000-8227-11e9-965f-4dcb775ae1a8.png)
![image](https://user-images.githubusercontent.com/3520460/58582190-92d0be80-8227-11e9-81b6-03fd97776e9a.png)
![image](https://user-images.githubusercontent.com/3520460/58582221-a7ad5200-8227-11e9-9ccf-b8053c2b6866.png)
![image](https://user-images.githubusercontent.com/3520460/58582251-b562d780-8227-11e9-8e2d-4b25da4af7ca.png)
