### PR TITLE
fix: spinner in reports ranking

### DIFF
--- a/assets/scss/templates/_reportes.scss
+++ b/assets/scss/templates/_reportes.scss
@@ -226,6 +226,7 @@
   margin: $dp-spaces--lv4 auto;
   font-family: $dp-font-family;
   position: relative;
+  min-height: 200px;
 
   .reports-box {
     @include dp-box($dp-color-sylver, 100%, 100%, 100%);


### PR DESCRIPTION
- Add min height to show spinner inside the box

![image](https://user-images.githubusercontent.com/8861133/58712653-5b811f80-8397-11e9-8e18-07d650aa505a.png)
