### PR TITLE
feat: remove hack in scrollbar

### DIFF
--- a/assets/scss/core/_reset.scss
+++ b/assets/scss/core/_reset.scss
@@ -25,22 +25,6 @@ RESET DOPPLER STYLE GUIDES
   box-sizing: border-box;
 }
 
-::-webkit-scrollbar-thumb {
-  background: rgba(0, 0, 0, 0.3);
-  border-radius: 10px;
-}
-
-::-webkit-scrollbar-track {
-  background: rgba(0, 0, 0, 0.1);
-  border-radius: 10px;
-  margin: 5px;
-}
-
-::-webkit-scrollbar {
-  width: 5px;
-  height: 5px;
-}
-
 html {
   line-height: 1.15;
   /* 1 */


### PR DESCRIPTION
To homogenize the scrollbar, it allows us to manipulate it cross browser in a uniform way.

![remove-hack-scrollbar](https://user-images.githubusercontent.com/46735526/60297688-24068400-98ff-11e9-94b6-7ce7890d873c.gif)


![browsers](https://user-images.githubusercontent.com/46735526/60297945-c9215c80-98ff-11e9-9938-8d5ab09b70ed.gif)
