### PR TITLE
fix(header): add classes instead of styles to hide header submenu

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -9,13 +9,13 @@ $('body').on({
     if (submenu[0] && submenu[0].children.length) {
       $('.header-main').addClass('header-open');
     } else {
-      $('.sub-menu.open').hide();
+      $('.sub-menu.open').removeClass('open');
     }
   },
   mouseleave: function() {
     if ($('.header-main .submenu-item > a.active').length > 0){
       $('.header-main').addClass('header-open');
-      $('.sub-menu.open').show(150);
+      $('.header-main .submenu-item > a.active + .sub-menu').addClass('open');
     } else {
       $('.header-main').removeClass('header-open');
     }


### PR DESCRIPTION
Because react does not override inline styles there was an issue with the header.  
Scenario: when in reports, hover another menu without sub items and then go to shopify, the result was that the menu did not hide when in shopify. 

http://cdn.fromdoppler.com/doppler-ui-library/build391/header.html