### PR TITLE
fix: image background adjustment to eliminate white space

### DIFF
--- a/assets/scss/templates/_signup.scss
+++ b/assets/scss/templates/_signup.scss
@@ -91,8 +91,11 @@
     .feature-panel--bg {
       background-size: cover;
       background-position: top;
-      height: 100%;
       padding: $dp-spaces--lv5 $dp-spaces--lv10;
+      height: 100%;
+      min-height: 968px;
+      max-height: 1200px;
+
       h1, h6, p {
         color: inherit;
       }


### PR DESCRIPTION
Image background adjustment to eliminate white space
Related to: http://jira.makingsense.com/browse/DBR-346

**Before**

![feature_panel_bg](https://user-images.githubusercontent.com/46735526/61400023-bfa76680-a8a5-11e9-97d1-c9dd920a067b.gif)


**After**

![fix_feature_panel_bg2](https://user-images.githubusercontent.com/46735526/61400054-d3eb6380-a8a5-11e9-866b-fd5fc2899273.gif)
