### PR TITLE
fix: to correct a hierarchy of inheritances in fonts

### DIFF
--- a/assets/scss/core/_reset.scss
+++ b/assets/scss/core/_reset.scss
@@ -38,7 +38,6 @@ html {
  */
 body {
   margin: 0;
-  font-family: var(--font-family);
   color: $dp-color-grey;
 }
 /**

--- a/assets/scss/core/_typography.scss
+++ b/assets/scss/core/_typography.scss
@@ -60,7 +60,6 @@ h3,
 h4,
 h5,
 h6 {
-  font: $dp-font;
   font-weight: $dp-font-weight;
   color: $dp-color-darkgrey;
 }
@@ -110,7 +109,6 @@ p {
 }
 
 small {
-  font: $dp-font;
   font-size: $dp-sizing--lvl2;
   line-height: $dp-font-small-lineheight;
 }

--- a/assets/scss/modules/_buttons.scss
+++ b/assets/scss/modules/_buttons.scss
@@ -59,6 +59,7 @@
         &:hover {
           background-color: $dp-color-darkgreen;
           border: 1px solid $dp-color-darkgreen;
+          color: $dp-color-white;
         }
       }
 
@@ -70,6 +71,7 @@
         &:hover {
           background-color: $dp-color-darkgrey;
           border: 1px solid $dp-color-darkgrey;
+          color: $dp-color-white;
         }
       }
     }


### PR DESCRIPTION
- The variable --font-family is deleted, it has no use
- the variable dp-font has as parameter ('font-weight', 'font-size', 'font-family')
- The titles had this variable + the declaration of font-weight + level-sizes.
- The variable dp-font of the h1, h2, h3, h4, h5, h6 was deleted by duplicate code.
- White color is added in the buttons hover