### PR TITLE
Fix build cleanup

### DIFF
--- a/build-n-release-w-docker.sh
+++ b/build-n-release-w-docker.sh
@@ -21,7 +21,7 @@ export MSYS2_ARG_CONV_EXCL="*"
 # Consider running this when local environment differs from docker environment
 # rm-rf node-modules
 
-rm -rf dist && mkdir dist
+mkdir -p dist
 
 docker run --rm \
     -e GH_TOKEN \
@@ -30,7 +30,8 @@ docker run --rm \
     -w /work \
     node:10 \
     /bin/sh -c "\
-      npm install -g gulp \
+      rm -rf ./dist/* \
+      && npm install -g gulp \
       && npm install \
       && ./node_modules/.bin/semantic-release \
     "

--- a/build-n-release-w-docker.sh
+++ b/build-n-release-w-docker.sh
@@ -34,6 +34,7 @@ docker run --rm \
       && npm install -g gulp \
       && npm install \
       && ./node_modules/.bin/semantic-release \
+      && chmod +777 -R ./dist/* \
     "
 
 # read pkgVersion from version.txt (see package.json => $.release.prepare[?(@.path=="@semantic-release/exec")])

--- a/build-w-docker.sh
+++ b/build-w-docker.sh
@@ -24,4 +24,5 @@ docker run --rm \
       rm -rf ./dist/* \
       && ./node_modules/.bin/eclint check \"**/*\" \
       && gulp dist \
+      && chmod +777 -R ./dist/* \
     "

--- a/build-w-docker.sh
+++ b/build-w-docker.sh
@@ -13,7 +13,7 @@ cd $(dirname $0)
 export MSYS_NO_PATHCONV=1
 export MSYS2_ARG_CONV_EXCL="*"
 
-rm -rf dist
+mkdir -p dist
 
 docker build --pull -t doppler-ui-system-source .
 docker run --rm \
@@ -21,6 +21,7 @@ docker run --rm \
     -p 3500:3500 \
     doppler-ui-system-source \
     /bin/sh -c "\
-      ./node_modules/.bin/eclint check \"**/*\" \
+      rm -rf ./dist/* \
+      && ./node_modules/.bin/eclint check \"**/*\" \
       && gulp dist \
     "


### PR DESCRIPTION
* Delete `dist` folder inside docker context

    It is to avoid issues in Jenkins who is trying to delete with `jenkins` user files created as `root` inside docker context

* Force public permissions to `dist` files to allow easily delete them
