### PR TITLE
fix: Include anchors in messages

### DIFF
--- a/assets/scss/modules/_messages.scss
+++ b/assets/scss/modules/_messages.scss
@@ -21,15 +21,47 @@
 }
 
 .dp-msj-error {
-  @include dp-messages($color:$dp-color-red, $border-color:$dp-color-red, $background:$dp-color-white)
+  @include dp-messages($color:$dp-color-red, $border-color:$dp-color-red, $background:$dp-color-white);
+
+  a {
+    color: $dp-color-red;
+    text-decoration: underline;
+
+    &:hover {
+      color: $dp-color-darkred;
+    }
+
+  }
+
 }
 .dp-msj-succes {
-  @include dp-messages($color:$dp-color-green, $border-color:$dp-color-green, $background:$dp-color-white)
+  @include dp-messages($color:$dp-color-green, $border-color:$dp-color-green, $background:$dp-color-white);
+
+  a {
+    text-decoration: underline;
+  }
+
 }
 .dp-msj-warning {
-  @include dp-messages($color:$dp-color-yellow, $border-color:$dp-color-yellow, $background:$dp-color-white)
+  @include dp-messages($color:$dp-color-yellow, $border-color:$dp-color-yellow, $background:$dp-color-white);
+
+  a {
+    color: $dp-color-yellow;
+    text-decoration: underline;
+
+    &:hover {
+      color: $dp-color-darkyellow;
+    }
+
+  }
+
 }
 .dp-msj-user {
-  @include dp-messages($color:$dp-color-lightgrey, $border-color:$dp-color-lightgrey, $background:$dp-color-white)
+  @include dp-messages($color:$dp-color-lightgrey, $border-color:$dp-color-lightgrey, $background:$dp-color-white);
+
+  a {
+    text-decoration: underline;
+  }
+
 }
 

--- a/assets/scss/templates/_integrations.scss
+++ b/assets/scss/templates/_integrations.scss
@@ -13,9 +13,6 @@
         padding: $dp-spaces--lv4;
       }
 
-      p {
-        margin-bottom: 0;
-      }
     }
 
     &__status {

--- a/assets/templates/partials/_msj-component.html
+++ b/assets/templates/partials/_msj-component.html
@@ -1,12 +1,12 @@
 <div class="dp-msj-error bounceIn">
-  <p>Ouch! These aren't VTEX api data connection ( Message Error )</p>
+  <p>Ouch! These aren't VTEX api data connection ( Message Error ) <a href="#">contact Support</a></p>
 </div>
 <div class="dp-msj-warning bounceIn">
-  <p>Ouch! These aren't VTEX api data connection ( Message Warning )</p>
+  <p>Ouch! These aren't VTEX api data connection ( Message Warning ) <a href="#">contact Support</a></p>
 </div>
 <div class="dp-msj-succes fadeInUp">
-  <p>Ouch! These aren't VTEX api data connection ( Message Succes )</p>
+  <p>Ouch! These aren't VTEX api data connection ( Message Succes ) <a href="#">contact Support</a></p>
 </div>
 <div class="dp-msj-user fadeInDown">
-  <p>Ouch! These aren't VTEX api data connection ( Message for User )</p>
+  <p>Ouch! These aren't VTEX api data connection ( Message for User ) <a href="#">contact Support</a></p>
 </div>


### PR DESCRIPTION
Include colors according to the message
Remove margin 0 in the `p`

![links_in_messages](https://user-images.githubusercontent.com/46735526/62240919-716a8b00-b3ae-11e9-9fbc-c4cd23f3028a.gif)
