### PR TITLE
fix: footer for pages with little content

### DIFF
--- a/assets/scss/templates/_integrations.scss
+++ b/assets/scss/templates/_integrations.scss
@@ -1,4 +1,7 @@
 .dp-integration {
+
+  margin-top: 20px;
+
   @at-root {
     &__block {
       @include dp-box($dp-color-silver, 100%, initial, initial);

--- a/assets/scss/templates/_layout.scss
+++ b/assets/scss/templates/_layout.scss
@@ -1,6 +1,15 @@
-.page-wrapper {
+.dp-container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.dp-page-wrapper {
   width: 100%;
   max-width: 1260px;
-  margin: 0 auto;
+  margin: 20px auto;
   padding: 0 30px;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
 }

--- a/assets/scss/templates/_layout.scss
+++ b/assets/scss/templates/_layout.scss
@@ -1,4 +1,4 @@
-.dp-container {
+.dp-app-container {
   display: flex;
   flex-direction: column;
   min-height: 100vh;


### PR DESCRIPTION
Use flexbox for footer alignment

![footer--position](https://user-images.githubusercontent.com/46735526/62396877-add2ee00-b54a-11e9-8b0c-3547f0913c4b.gif)
