### PR TITLE
Documentation improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Simply including the css and js file in your html. Just check the correct versio
 **JS** (optional, you can include your own js instead)
 `<script type="text/javascript" src="https://cdn.fromdoppler.com/doppler-ui-library/vx.x.x/js/app.js"></script>`
 
+# How to apply components and use mixins?
+
+Check our [Documentation](http://cdn.fromdoppler.com/doppler-ui-library/latest/documentation/index.html)
+
 # Contributing to this project
 
 If you want to contribute to this project you should follow the rules:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -91,9 +91,12 @@ var config = {
       display: {
         watermark: false
       },
-    // theme: './node_modules/sassdoc-theme-flippant', // para agregar un theme en particular
     groups: {
-      'undefined': 'General'
+      'undefined': 'general'
+    },
+    package: {
+      title: "Doppler UI Library",
+      homepage: "/",
     }
   },
   sassdocOptionsDist: {
@@ -102,7 +105,11 @@ var config = {
         watermark: false
       },
     groups: {
-      'undefined': 'General'
+      'undefined': 'general'
+    },
+    package: {
+      title: "Doppler UI Library",
+      homepage: "/",
     }
   }
 };


### PR DESCRIPTION
- Added title in docs with link to style guide.  (Doppler UI Library)
![image](https://user-images.githubusercontent.com/2439363/62953097-424b1500-bdc3-11e9-9092-792d74431320.png)

A link to documentation in style guide will be provided in next layout. 
- Added documentation link in readme.

https://cdn.fromdoppler.com/doppler-ui-library/build484/documentation/
