### PR TITLE
fix(dp-box): remove the overflow-hidden in the box-shadow mixin

### DIFF
--- a/assets/scss/modules/_box.scss
+++ b/assets/scss/modules/_box.scss
@@ -15,5 +15,4 @@
   min-height: $min-height;
   border: 1px solid $color;
   box-shadow: 0 0 0 4px rgba($color, 0.3);
-  overflow: hidden;
 }


### PR DESCRIPTION
#Checklist

- [X] Check if there is a new color.
- [X] Create the color variable in the _colors.scss file.
- [X] Follow the color nomenclature.
- [X] Create the color class with its variable.
- [X] Create the color component in the html, show the name, color class and its exadecimal.

![remove-overflow-hidden](https://user-images.githubusercontent.com/46735526/68478229-2adac700-020e-11ea-8011-b6899a09b1c7.jpg)

