### PR TITLE
fix: Add the dp-boxshadow class error

### DIFF
--- a/assets/scss/modules/_grid-system.scss
+++ b/assets/scss/modules/_grid-system.scss
@@ -74,6 +74,11 @@
   min-height: 100%;
   border: 1px solid $dp-color-silver;
   position: relative;
+
+  .dp-boxshadow--error {
+    padding: $dp-spaces--lv5 $dp-spaces--lv6;
+    color: $dp-color-red;
+  }
 }
 
 .dpsg-content-sample {

--- a/assets/scss/modules/_grid-system.scss
+++ b/assets/scss/modules/_grid-system.scss
@@ -76,8 +76,12 @@
   position: relative;
 
   .dp-boxshadow--error {
-    padding: $dp-spaces--lv5 $dp-spaces--lv6;
+    padding: $dp-spaces--lv5;
     color: $dp-color-red;
+
+    a {
+      text-decoration: underline;
+    }
   }
 }
 

--- a/assets/templates/grid-system-component.html
+++ b/assets/templates/grid-system-component.html
@@ -103,11 +103,9 @@
               <div class="dp-rowflex">
                 <div class="col-sm-12 col-md-8 col-lg-6 m-b-12">
                   <div class="dp-box-shadow dpsg-content-sample">
-                    <p>
-                      Lorem ipsum, dolor sit amet consectetur adipisicing elit.
-                      Eius, ipsum pariatur hic tempore voluptate facere quam
-                      omnis debitis incidunt in neque maiores molestias nesciunt
-                      perspiciatis laboriosam temporibus dolorum. Beatae, ex.
+                    <p class="dp-boxshadow--error">
+                      Class para transmitir Mensajes de error dentro de
+                      dp-box-shadow!
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
Add the dp-boxshadow class error to handle errors inside dp-box-shadow boxes
Related to: https://github.com/FromDoppler/doppler-webapp/pull/580

#Checklist

- [X] Check if there is a new color.
- [X] Create the color variable in the _colors.scss file.
- [X] Follow the color nomenclature.
- [X] Create the color class with its variable.
- [X] Create the color component in the html, show the name, color class and its exadecimal.

![messages-error](https://user-images.githubusercontent.com/46735526/68813227-f4f57280-0653-11ea-8256-66f0f353e845.jpg)

