### PR TITLE
fix: Add gray message to user in dp-box-shadow

### DIFF
--- a/assets/scss/modules/_grid-system.scss
+++ b/assets/scss/modules/_grid-system.scss
@@ -71,13 +71,27 @@
   @include dp-box($dp-color-silver, 30%, 408px, 250px);
   width: 100%;
   max-width: 100%;
-  min-height: 100%;
+  min-height: 80px;
   border: 1px solid $dp-color-silver;
   position: relative;
 
   .dp-boxshadow--error {
-    padding: $dp-spaces--lv5;
+    padding: $dp-spaces--lv5 $dp-spaces--lv7;
     color: $dp-color-red;
+
+    a {
+      text-decoration: underline;
+      color: $dp-color-red;
+
+      &:hover {
+        color: $dp-color-darkred;
+      }
+    }
+  }
+
+  .dp-boxshadow--usermsg {
+    padding: $dp-spaces--lv5 $dp-spaces--lv7;
+    color: $dp-color-lightgrey;
 
     a {
       text-decoration: underline;

--- a/assets/templates/grid-system-component.html
+++ b/assets/templates/grid-system-component.html
@@ -105,17 +105,15 @@
                   <div class="dp-box-shadow dpsg-content-sample">
                     <p class="dp-boxshadow--error">
                       Class para transmitir Mensajes de error dentro de
-                      dp-box-shadow!
+                      dp-box-shadow!. <a href="#">text link</a>
                     </p>
                   </div>
                 </div>
                 <div class="col-sm-12 col-md-4 col-lg-6 m-b-12">
                   <div class="dp-box-shadow dpsg-content-sample">
-                    <p>
-                      Lorem ipsum, dolor sit amet consectetur adipisicing elit.
-                      Eius, ipsum pariatur hic tempore voluptate facere quam
-                      omnis debitis incidunt in neque maiores molestias nesciunt
-                      perspiciatis laboriosam temporibus dolorum. Beatae, ex.
+                    <p class="dp-boxshadow--usermsg">
+                      Class para transmitir Mensajes genéricos al usuario dentro
+                      de dp-box-shadow!. <a href="#">text link</a>
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
#Checklist

- [X] Check if there is a new color.
- [X] Create the color variable in the _colors.scss file.
- [X] Follow the color nomenclature.
- [X] Create the color class with its variable.
- [X] Create the color component in the html, show the name, color class and its exadecimal.


![messages-user](https://user-images.githubusercontent.com/46735526/69233682-20082680-0b6c-11ea-8dfd-5301691feb4e.jpg)
