### PR TITLE
fix: outline function enabled for keyboard navigation in the select

### DIFF
--- a/assets/scss/core/_reset.scss
+++ b/assets/scss/core/_reset.scss
@@ -206,9 +206,6 @@ select {
   text-transform: none;
 }
 
-select {
-  outline: none;
-}
 /**
  * Correct the inability to style clickable types in iOS and Safari.
  */

--- a/assets/scss/modules/_forms.scss
+++ b/assets/scss/modules/_forms.scss
@@ -91,7 +91,7 @@ select {
   cursor: pointer;
   -webkit-appearance: button;
   box-shadow: 0 0 2px rgba(0, 0, 0, 0.1);
-  outline: none;
+  //outline: none;
 }
 
 select:disabled {

--- a/assets/scss/modules/_language.scss
+++ b/assets/scss/modules/_language.scss
@@ -38,7 +38,7 @@ Language selector
   }
 
   a[role='menuitem'] {
-    outline: 0;
+    //outline: 0;
     box-shadow: 0 0 0 1px $dp-color-darkyellow, 0 0 0 2px rgba(0, 0, 0, 0.1);
 
     &:hover,


### PR DESCRIPTION
#Checklist

- [X] Check if there is a new color.
- [X] Create the color variable in the _colors.scss file.
- [X] Follow the color nomenclature.
- [X] Create the color class with its variable.
- [X] Create the color component in the html, show the name, color class and its exadecimal.

Related to: https://github.com/FromDoppler/doppler-webapp/pull/618

![outline-enabled](https://user-images.githubusercontent.com/46735526/69891221-a0035e80-12d9-11ea-8dcd-ee615601164b.gif)

