### PR TITLE
fix(semantic-release): fixed script

### DIFF
--- a/build-n-release-w-docker.sh
+++ b/build-n-release-w-docker.sh
@@ -23,17 +23,20 @@ export MSYS2_ARG_CONV_EXCL="*"
 
 mkdir -p dist
 
-docker build --pull -t doppler-ui-system-source --target test .
+docker build --pull -t doppler-ui-system-source .
 
 docker run --rm \
     -e GH_TOKEN \
     -e "NPM_TOKEN=00000000-0000-0000-0000-000000000000" \
     -v `pwd`/.git:/work/.git \
+    -v `pwd`/dist:/work/result \
+    -w /work \
     doppler-ui-system-source \
     /bin/sh -c "\
-      rm -rf ./dist/* \
-      && ./node_modules/.bin/semantic-release \
+      mkdir -p dist \
       && chmod +777 -R --quiet ./dist/* \
+      && cp -R ./dist/* ./result/ \
+      && ./node_modules/.bin/semantic-release \
     "
 
 # It seems that due a change in semantic release, when no version is generated


### PR DESCRIPTION
### Fix for release script
Semantic release needs dist folder created with build to generate the tag, this is a bit different in doppler webapp. 

#Checklist

- [X] Check if there is a new color.
- [x] Create the color variable in the _colors.scss file.
- [x] Follow the color nomenclature.
- [x] Create the color class with its variable.
- [x] Create the color component in the html, show the name, color class and its exadecimal.

@andresmoschini I'm tagging you here just in case. 
