### PR TITLE
fix(Node): cannot use more than 10 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:10.18.1 as source
+FROM node:12.16.3 as source
 WORKDIR /work
 
 RUN npm install -g gulp
-COPY package-lock.json package.json ./
+COPY package-lock.json package.json npm-shrinkwrap.json ./
 RUN npm install
 
 COPY assets/ ./assets/

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "graceful-fs": {
+        "version": "4.2.2"
+     }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
   },
   "main": "pdr",
   "engines": {
-    "node": ">=6.9.1",
-    "npm": ">=3.10.9"
+    "node": ">=12.16.3",
+    "npm": ">=6.14.4"
   },
   "dependencies": {},
   "release": {


### PR DESCRIPTION
- Add one more json file to install the dependencies to node version 12 and dont change gulp 3.
 
The explanation is here: https://timonweb.com/posts/how-to-fix-referenceerror-primordials-is-not-defined-error/
