### PR TITLE
feat: improvement in the pseudo-class: focus

### DIFF
--- a/assets/scss/helpers/_colors.scss
+++ b/assets/scss/helpers/_colors.scss
@@ -25,6 +25,7 @@ $dp-color-lightbrown: #838370;
 $dp-color-brown: #302100;
 $dp-color-brown--hover: #594103;
 $dp-color-brown-brightness: rgba(48, 33, 0, 0.2);
+$dp-color-orange-focus: #e79433;
 
 /// Internal use color variables
 
@@ -155,4 +156,8 @@ $dpsg-orange: #ee7752;
 
 .dp-brown-brightness {
   background: $dp-color-brown-brightness;
+}
+
+.dp-color-orange-focus {
+  background: $dp-color-orange-focus;
 }

--- a/assets/scss/modules/_buttons.scss
+++ b/assets/scss/modules/_buttons.scss
@@ -61,36 +61,30 @@
     &.primary- {
       &green {
         background-color: $dp-color-green;
-        border: 1px solid $dp-color-green;
         color: $dp-color-white;
 
         &:hover {
           background-color: $dp-color-darkgreen;
-          border: 1px solid $dp-color-darkgreen;
           color: $dp-color-white;
         }
       }
 
       &grey {
         background-color: $dp-color-grey;
-        border: 1px solid $dp-color-grey;
         color: $dp-color-white;
 
         &:hover {
           background-color: $dp-color-darkgrey;
-          border: 1px solid $dp-color-darkgrey;
           color: $dp-color-white;
         }
       }
 
       &brown {
         background-color: $dp-color-brown;
-        border: 1px solid $dp-color-brown;
         color: $dp-color-white;
 
         &:hover {
           background-color: $dp-color-brown--hover;
-          border: 1px solid $dp-color-brown--hover;
           color: $dp-color-white;
         }
       }
@@ -99,20 +93,32 @@
     &.secondary- {
       &green {
         background: transparent;
-        border: 1px solid $dp-color-green;
         color: $dp-color-green;
+        box-shadow: inset 0 0 0 1px $dp-color-green;
 
         &:hover {
+          background: $dp-color-green-brightness;
+        }
+
+        &:focus {
+          box-shadow: inset 0 0 0 2px $dp-color-orange-focus,
+            inset 0 0 0 3px $dp-color-white;
           background: $dp-color-green-brightness;
         }
       }
 
       &brown {
         background: transparent;
-        border: 1px solid $dp-color-brown;
         color: $dp-color-brown;
+        box-shadow: inset 0 0 0 1px $dp-color-brown;
 
         &:hover {
+          background: $dp-color-brown-brightness;
+        }
+
+        &:focus {
+          box-shadow: inset 0 0 0 2px $dp-color-orange-focus,
+            inset 0 0 0 3px $dp-color-white;
           background: $dp-color-brown-brightness;
         }
       }
@@ -163,6 +169,7 @@
 
   button:focus {
     outline: none;
-    box-shadow: inset 0 0 0 1px #e79433, inset 0 0 0 2px #ffffff;
+    box-shadow: inset 0 0 0 2px $dp-color-orange-focus,
+      inset 0 0 0 3px $dp-color-white;
   }
 }

--- a/assets/scss/modules/_buttons.scss
+++ b/assets/scss/modules/_buttons.scss
@@ -160,4 +160,9 @@
 }
 .dp-library {
   @include dp-button();
+
+  button:focus {
+    outline: none;
+    box-shadow: inset 0 0 0 1px #e79433, inset 0 0 0 2px #ffffff;
+  }
 }

--- a/assets/scss/modules/_forms.scss
+++ b/assets/scss/modules/_forms.scss
@@ -116,10 +116,6 @@
       color: $dp-color-default;
       font-style: italic;
     }
-
-    :focus {
-      border: 1px solid $dp-color-yellow;
-    }
   }
 
   .checkmark {
@@ -206,11 +202,17 @@
   }
 
   input[type='checkbox'] {
-    opacity: 0;
-    z-index: 0;
     cursor: pointer;
-    zoom: 2.5;
     position: absolute;
+    width: 14px;
+    height: 14px;
+
+    &:focus {
+      outline: 4px solid #e79433;
+      outline-offset: 0px;
+      top: 1px;
+      left: 1px;
+    }
 
     &:checked {
       & ~ .checkmark {
@@ -549,5 +551,13 @@
       border-top-color: $dp-color-silver;
       left: 9px;
     }
+  }
+
+  select:focus,
+  textarea:focus,
+  input:focus {
+    outline: none;
+    border: 1px solid #e79433;
+    box-shadow: inset 0 0 0 2px #e79433;
   }
 }

--- a/assets/scss/modules/_forms.scss
+++ b/assets/scss/modules/_forms.scss
@@ -208,7 +208,7 @@
     height: 14px;
 
     &:focus {
-      outline: 4px solid #e79433;
+      outline: 3px solid $dp-color-orange-focus;
       outline-offset: 0px;
       top: 1px;
       left: 1px;
@@ -557,7 +557,7 @@
   textarea:focus,
   input:focus {
     outline: none;
-    border: 1px solid #e79433;
-    box-shadow: inset 0 0 0 2px #e79433;
+    border: 1px solid $dp-color-orange-focus;
+    box-shadow: inset 0 0 0 2px $dp-color-orange-focus;
   }
 }

--- a/assets/scss/templates/_guidelines.scss
+++ b/assets/scss/templates/_guidelines.scss
@@ -1569,6 +1569,17 @@ body {
   .dpsg-color-card.dpsg-brown-brightness:hover .dpsg-icon-color {
     box-shadow: 0 0 0 400px $dp-color-brown-brightness;
   }
+
+  /* color 25 */
+
+  .dpsg-color-card.dpsg-orange-focus .dpsg-icon-color {
+    box-shadow: 0 0 0 0 $dp-color-orange-focus;
+    background: $dp-color-orange-focus;
+  }
+
+  .dpsg-color-card.dpsg-orange-focus:hover .dpsg-icon-color {
+    box-shadow: 0 0 0 400px $dp-color-orange-focus;
+  }
 }
 
 /* Content text General */

--- a/assets/templates/colors-component.html
+++ b/assets/templates/colors-component.html
@@ -378,6 +378,18 @@
                   </p>
                 </div>
               </div>
+              <div class="dpsg-color-card dpsg-orange-focus">
+                <div class="dpsg-icon-color">Color</div>
+                <div class="dpsg-content-color">
+                  <h3>Orange :focus</h3>
+                  <p class="dpsg-code">
+                    Color: #e79433;
+                  </p>
+                  <p class="dpsg-code">
+                    .$dp-color-orange-focus
+                  </p>
+                </div>
+              </div>
             </div>
           </article>
         </div>

--- a/assets/templates/signup.html
+++ b/assets/templates/signup.html
@@ -158,7 +158,9 @@
                 <label for="password"
                   >Contraseña:
                   <a
+                    href="#"
                     toggle="#password-field"
+                    rel="noopener"
                     class="ms-icon icon-view show-hide"
                   >
                     <span class="content-eye">Mostrar</span></a


### PR DESCRIPTION
Improvement in the pseudo-class: focus to be able to navigate the forms with tab and improve our accessibility

![focus-form](https://user-images.githubusercontent.com/46735526/82708076-c9cb8b80-9c53-11ea-963e-2364d80efe14.gif)

#Checklist

- [X] Check if there is a new color.
- [X] Create the color variable in the _colors.scss file.
- [X] Follow the color nomenclature.
- [X] Create the color class with its variable.
- [X] Create the color component in the html, show the name, color class and its exadecimal.

Look: http://cdn.fromdoppler.com/doppler-ui-library/build871/signup.html

![focus-buttons](https://user-images.githubusercontent.com/46735526/82707916-69d4e500-9c53-11ea-85be-79fddcea3756.gif)

