### PR TITLE
fix: remove tooltip in small resolutions

### DIFF
--- a/assets/scss/modules/_tooltip.scss
+++ b/assets/scss/modules/_tooltip.scss
@@ -51,6 +51,12 @@
 
   /// tooltip top
 
+  @media screen and (max-width: 1365px) {
+    .dp-tooltip-container {
+      display: none;
+    }
+  }
+
   .dp-tooltip-top {
     span {
       width: 170px;


### PR DESCRIPTION
**remove tooltip in small resolutions**

👁️‍🗨️ : https://cdn.fromdoppler.com/doppler-ui-library/build1023/plan-calculator.html


![remove_tooltip_small_resolutions](https://user-images.githubusercontent.com/46735526/96879920-fc6fef00-1452-11eb-8622-ab2b1d114e73.gif)


#Checklist

- [X] Check if there is a new color.
- [X] Create the color variable in the _colors.scss file.
- [X] Follow the color nomenclature.
- [X] Create the color class with its variable.
- [X] Create the color component in the html, show the name, color class and its exadecimal.
