### PR TITLE
feat: replace font-face with the link tag to the official proxima-nova

### DIFF
--- a/assets/scss/core/_settings.scss
+++ b/assets/scss/core/_settings.scss
@@ -19,7 +19,7 @@ $dp-font-weight-regular: $dp-font-weight !default;
 ///
 $dp-font-size: 15px !default;
 ///
-$dp-font-family: Arial, sans-serif !default;
+$dp-font-family: 'proxima-nova', helvetica, arial, sans-serif;
 $dp-font-family-proximanova: 'proxima-nova', Helvetica, Arial, sans-serif !default;
 $dp-font-family-handofsean: 'hand-of-sean';
 ///

--- a/assets/scss/core/_typography.scss
+++ b/assets/scss/core/_typography.scss
@@ -5,64 +5,6 @@
 ////
 
 ///
-@font-face {
-  font-family: 'proxima-nova';
-  src: url('../fonts/proxima-nova.eot');
-  src: url('../fonts/proxima-nova.eot?#iefix') format('embedded-opentype'),
-    url('../fonts/proxima-nova.woff2') format('woff2'),
-    url('../fonts/proxima-nova.woff') format('woff'),
-    url('.../fonts/proxima-nova.ttf') format('truetype');
-  font-weight: $dp-font-weight;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'proxima-nova';
-  src: url('../fonts/proxima-nova-italic.eot');
-  src: url('../fonts/proxima-nova-italic.eot?#iefix')
-      format('embedded-opentype'),
-    url('../fonts/proxima-nova-italic.woff2') format('woff2'),
-    url('../fonts/proxima-nova-italic.woff') format('woff'),
-    url('.../fonts/proxima-nova-italic.ttf') format('truetype');
-  font-weight: $dp-font-weight;
-  font-style: italic;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'proxima-nova';
-  src: url('../fonts/proxima-nova-bold.eot');
-  src: url('../fonts/proxima-nova-bold.eot?#iefix') format('embedded-opentype'),
-    url('../fonts/proxima-nova-bold.woff2') format('woff2'),
-    url('../fonts/proxima-nova-bold.woff') format('woff'),
-    url('../fonts/proxima-nova-bold.ttf') format('truetype');
-  font-weight: bold;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'proxima-nova';
-  src: url('../fonts/proxima-nova-bold-italic.eot');
-  src: url('../fonts/proxima-nova-bold-italic.eot?#iefix')
-      format('embedded-opentype'),
-    url('../fonts/proxima-nova-bold-italic.woff2') format('woff2'),
-    url('../fonts/proxima-nova-bold-italic.woff') format('woff'),
-    url('../fonts/proxima-nova-bold-italic.ttf') format('truetype');
-  font-weight: bold;
-  font-style: italic;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'hand-of-sean';
-  src: url('../fonts/HandOfSeanPro-webfont.eot');
-  src: url('../fonts/HandOfSeanPro-webfont.eot?#iefix')
-      format('embedded-opentype'),
-    url('../fonts/HandOfSeanPro-webfont.woff2') format('woff2'),
-    url('../fonts/HandOfSeanPro-webfont.woff') format('woff'),
-    url('../fonts/HandOfSeanPro-webfont.ttf') format('truetype');
-  font-weight: $dp-font-weight;
-  font-style: normal;
-  font-display: swap;
-}
 
 .dp-library {
   body {

--- a/assets/scss/templates/_guidelines.scss
+++ b/assets/scss/templates/_guidelines.scss
@@ -355,7 +355,7 @@ body {
     display: inline-block;
     color: $dp-color-black;
     position: relative;
-    font-family: Arial, Helvetica, sans-serif;
+    font-family: $dp-font-family;
     line-height: 1.2em;
   }
 

--- a/assets/templates/_index.html
+++ b/assets/templates/_index.html
@@ -16,6 +16,8 @@
     <meta property="og:description" content="" />
     <meta property="og:site_name" content="" />
     <!-- Stylesheets and polyfills -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/accordion-component.html
+++ b/assets/templates/accordion-component.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Accordion component" />
     <meta property="og:site_name" content="Accordion component" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/account-message-component.html
+++ b/assets/templates/account-message-component.html
@@ -22,6 +22,9 @@
     <meta property="og:description" content="Account Message component" />
     <meta property="og:site_name" content="Account Message component" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/animations-component.html
+++ b/assets/templates/animations-component.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Animations component" />
     <meta property="og:site_name" content="Animations component" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/big-data-input.html
+++ b/assets/templates/big-data-input.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Doppler Plus Plans Form" />
     <meta property="og:site_name" content="Doppler Plus Plans Form" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/breadcrumb-component.html
+++ b/assets/templates/breadcrumb-component.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Breadcrumb component" />
     <meta property="og:site_name" content="Breadcrumb component" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/buttons-component.html
+++ b/assets/templates/buttons-component.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Buttons component" />
     <meta property="og:site_name" content="Buttons component" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/cards-component.html
+++ b/assets/templates/cards-component.html
@@ -16,6 +16,9 @@
     <meta property="og:description" content="Layout Reports" />
     <meta property="og:site_name" content="Layout Reports" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/colors-component.html
+++ b/assets/templates/colors-component.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Colors component" />
     <meta property="og:site_name" content="Colors component" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/confirmation-page.html
+++ b/assets/templates/confirmation-page.html
@@ -16,6 +16,9 @@
     <meta property="og:description" content="Confirmation page" />
     <meta property="og:site_name" content="Confirmation page" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/doppler-plus-plans-form.html
+++ b/assets/templates/doppler-plus-plans-form.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Doppler Plus Plans Form" />
     <meta property="og:site_name" content="Doppler Plus Plans Form" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/doppler-plus.html
+++ b/assets/templates/doppler-plus.html
@@ -16,6 +16,9 @@
     <meta property="og:description" content="Layout Reports" />
     <meta property="og:site_name" content="Layout Reports" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/footer-component.html
+++ b/assets/templates/footer-component.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Footer component" />
     <meta property="og:site_name" content="Footer component" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/forgot-password.html
+++ b/assets/templates/forgot-password.html
@@ -16,6 +16,9 @@
     <meta property="og:description" content="Forgot Password layout" />
     <meta property="og:site_name" content="Forgot Password layout" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/form_exclusive_features.html
+++ b/assets/templates/form_exclusive_features.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Form exclusive features" />
     <meta property="og:site_name" content="Form exclusive features" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/grid-system-component.html
+++ b/assets/templates/grid-system-component.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Grid System" />
     <meta property="og:site_name" content="Grid System" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/header-component.html
+++ b/assets/templates/header-component.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Header component" />
     <meta property="og:site_name" content="Header component" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/hero-banner-component.html
+++ b/assets/templates/hero-banner-component.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Breadcrumb component" />
     <meta property="og:site_name" content="Breadcrumb component" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/index.html
+++ b/assets/templates/index.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Home layout" />
     <meta property="og:site_name" content="Home layout" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/integrations.html
+++ b/assets/templates/integrations.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Integration Shopify layout" />
     <meta property="og:site_name" content="Integration Shopify layout" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/login.html
+++ b/assets/templates/login.html
@@ -16,6 +16,9 @@
     <meta property="og:description" content="Login layout" />
     <meta property="og:site_name" content="Login layout" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/messages-component.html
+++ b/assets/templates/messages-component.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Messages component" />
     <meta property="og:site_name" content="Messages component" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/modal-component.html
+++ b/assets/templates/modal-component.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Modal component" />
     <meta property="og:site_name" content="Modal component" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/nav-user-component.html
+++ b/assets/templates/nav-user-component.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Breadcrumb component" />
     <meta property="og:site_name" content="Breadcrumb component" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/notification-poc.html
+++ b/assets/templates/notification-poc.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Notification POC" />
     <meta property="og:site_name" content="Notification POC" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/plan-calculator.html
+++ b/assets/templates/plan-calculator.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Layout Plan Calculator" />
     <meta property="og:site_name" content="Layout Plan Calculator" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/preload-component.html
+++ b/assets/templates/preload-component.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Preload Component" />
     <meta property="og:site_name" content="Preload Component" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/reports.html
+++ b/assets/templates/reports.html
@@ -16,6 +16,9 @@
     <meta property="og:description" content="Layout Reports" />
     <meta property="og:site_name" content="Layout Reports" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/signup.html
+++ b/assets/templates/signup.html
@@ -16,6 +16,9 @@
     <meta property="og:description" content="Signup layout" />
     <meta property="og:site_name" content="Signup layout" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/subscriber-history.html
+++ b/assets/templates/subscriber-history.html
@@ -22,6 +22,9 @@
     <meta property="og:description" content="Subscriber History Layout" />
     <meta property="og:site_name" content="Subscriber History Layout" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/table-component.html
+++ b/assets/templates/table-component.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Table component" />
     <meta property="og:site_name" content="Table component" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/tabs-component.html
+++ b/assets/templates/tabs-component.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Breadcrumb component" />
     <meta property="og:site_name" content="Breadcrumb component" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link

--- a/assets/templates/themes.html
+++ b/assets/templates/themes.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Integration Shopify layout" />
     <meta property="og:site_name" content="Integration Shopify layout" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Themes-->
     <link rel="stylesheet" type="text/css" href="./css/theme-dark.css" />

--- a/assets/templates/tooltip-component.html
+++ b/assets/templates/tooltip-component.html
@@ -19,6 +19,9 @@
     <meta property="og:description" content="Tooltip component" />
     <meta property="og:site_name" content="Tooltip component" />
     <!-- Stylesheets and polyfills -->
+    <!-- Font Proxima Nova -->
+    <link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+    <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     <!-- Favicons -->
     <link


### PR DESCRIPTION
Replace font-face with the link tag to the official proxima-nova page

![proxima-nova](https://user-images.githubusercontent.com/46735526/112687305-0f4d7c00-8e56-11eb-8d1c-56615412ee4d.gif)


#Checklist

- [X] Check if there is a new color.
- [X] Create the color variable in the _colors.scss file.
- [X] Follow the color nomenclature.
- [X] Create the color class with its variable.
- [X] Create the color component in the html, show the name, color class and its exadecimal.
