### PR TITLE
fix(DopplerApp): blocked segment tag styles in segments grid

### DIFF
--- a/assets/scss/modules/_tables.scss
+++ b/assets/scss/modules/_tables.scss
@@ -369,5 +369,6 @@
     border-radius: 3px;
     overflow: hidden;
     font-weight: 700;
+    line-height: initial;
   }
 }


### PR DESCRIPTION
Fix vertical alignment text in blocked segment/lists tag in the segments and lists grid in app

![image](https://user-images.githubusercontent.com/8861133/117294514-17cba600-ae49-11eb-9b58-1497e6477666.png)


- [] Check if there is a new color.
- [] Create the color variable in the _colors.scss file.
- [] Follow the color nomenclature.
- [] Create the color class with its variable.
- [] Create the color component in the html, show the name, color class and its exadecimal.
