### PR TITLE
fix: tooltip left class for user menu

### DIFF
--- a/assets/scss/modules/_tooltip.scss
+++ b/assets/scss/modules/_tooltip.scss
@@ -158,9 +158,42 @@
     @include dp-tooltip($dp-sizing--lvl1, $dp-color-white);
 
     .tooltiptext {
-      transform: translate(-50%, -50%);
-      left: -100px;
-      top: 50%;
+      transform: translate(-140%, -50%);
+      padding: 12px;
+      min-height: 86px;
+      font-size: 13px;
+      height: 100%;
+      text-transform: initial;
+
+      &.transform-left {
+        transform: translate(-105%, -50%);
+      }
+
+      .dp-tooltip-left {
+        opacity: 0;
+        color: $dp-color-darkgrey;
+        width: max-content;
+        min-width: 150px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        font-size: $dp-sizing--lvl2;
+        line-height: 15px;
+        padding: $dp-spaces--lv2 $dp-spaces--lv3;
+        border-radius: $dp-border-radius;
+        text-align: center;
+        color: $dp-color-white;
+        background: rgba(51, 51, 51, 0.9);
+        transition: all 0.2s ease-in-out;
+        transform: scale(0);
+        position: absolute;
+        top: -12px;
+        left: 50%;
+        border: 1px solid $dp-color-silver;
+        transform: translate(-50%, -50%);
+        z-index: -1;
+        visibility: visible;
+      }
 
       &:after {
         top: 50%;

--- a/assets/scss/templates/_header.scss
+++ b/assets/scss/templates/_header.scss
@@ -424,9 +424,8 @@
         top: 3px;
       }
 
-      .dp-tooltip-top {
-        top: -7px;
-        left: 20%;
+      .tooltiptext {
+        top: 6px;
       }
     }
   }

--- a/assets/templates/header-component.html
+++ b/assets/templates/header-component.html
@@ -168,6 +168,23 @@
                         </button>
                       </div>
                       <div class="user-plan--type">
+                        <p><strong>498</strong> Suscriptores disponibles</p>
+                        <div class="dp-request-sent">
+                          <button
+                            class="user-plan close-user--menu dp-tooltip-left"
+                            type="button"
+                          >
+                            solicitud enviada
+                            <div class="tooltiptext">
+                              Estamos diseñando un Plan a la medida de tus
+                              necesidades.¡Te contactaremos pronto!
+                            </div>
+                          </button>
+                          <span class="ms-icon icon-info-icon"></span>
+                          <div class="dp-tooltip-container"></div>
+                        </div>
+                      </div>
+                      <div class="user-plan--type">
                         <p><strong>250</strong> Suscriptores disponibles</p>
                       </div>
                     </div>

--- a/assets/templates/nav-user-component.html
+++ b/assets/templates/nav-user-component.html
@@ -105,18 +105,18 @@
                   <div class="user-plan--type">
                     <p><strong>498</strong> Suscriptores disponibles</p>
                     <div class="dp-request-sent">
-                      <button class="user-plan close-user--menu" type="button">
+                      <button
+                        class="user-plan close-user--menu dp-tooltip-left"
+                        type="button"
+                      >
                         solicitud enviada
-                      </button>
-                      <div class="dp-tooltip-container">
-                        <span class="ms-icon icon-info-icon"></span>
-                        <div class="dp-tooltip-top">
-                          <span
-                            >Estamos diseñando un Plan a la medida de tus
-                            necesidades.¡Te contactaremos pronto!
-                          </span>
+                        <div class="tooltiptext">
+                          Estamos diseñando un Plan a la medida de tus
+                          necesidades.¡Te contactaremos pronto!
                         </div>
-                      </div>
+                      </button>
+                      <span class="ms-icon icon-info-icon"></span>
+                      <div class="dp-tooltip-container"></div>
                     </div>
                   </div>
                 </div>

--- a/assets/templates/tooltip-component.html
+++ b/assets/templates/tooltip-component.html
@@ -143,10 +143,10 @@
                 <p>
                   Tooltip left
                   <span class="ms-icon icon-tip-icon dp-tooltip-left">
-                    <span class="tooltiptext"
-                      >Lorem ipsum dolor sit amet.
-                      <a href="#">tips para seguir</a></span
-                    >
+                    <span class="tooltiptext">
+                      Lorem ipsum dolor sit amet.
+                      <a href="#">tips para seguir</a>
+                    </span>
                   </span>
                 </p>
               </div>


### PR DESCRIPTION

![tooltip-left-user-menu-01](https://user-images.githubusercontent.com/46735526/123168206-0b79c780-d44e-11eb-96df-31e6cbdf869f.gif)

![tooltip-left-user-menu-03](https://user-images.githubusercontent.com/46735526/123168227-12083f00-d44e-11eb-8cc9-0c3dbdfb1f17.gif)

![tooltip-left-user-menu-02](https://user-images.githubusercontent.com/46735526/123168215-0caaf480-d44e-11eb-9c7e-b4dd75ae6343.gif)



#Checklist

- [X] Check if there is a new color.
- [X] Create the color variable in the _colors.scss file.
- [X] Follow the color nomenclature.
- [X] Create the color class with its variable.
- [X] Create the color component in the html, show the name, color class and its exadecimal.
