### PR TITLE
Fix(.gitattributes): add font extensions as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,7 @@
 *.jpg binary
 *.gif binary
 *.png binary
+*.ttf binary
+*.eot binary
+*.woff binary
+*.woff2 binary


### PR DESCRIPTION
## Checklist
_* Fix(.gitattributes): add font extensions as binary to fix git extension binaries error._
- [] Check if there is a new color.
- [] Create the color variable in the _colors.scss file.
- [] Follow the color nomenclature.
- [] Create the color class with its variable.
- [] Create the color component in the html, show the name, color class and its exadecimal.
