### PR TITLE
feat: add button component with centered preload

### DIFF
--- a/assets/scss/modules/_buttons.scss
+++ b/assets/scss/modules/_buttons.scss
@@ -49,6 +49,20 @@
       }
     }
 
+    &.button--centered-loading {
+      @include dp-preloader($dp-color-white, 1.5em);
+
+      position: relative;
+      display: flex;
+      align-items: center;
+      height: 30px;
+
+      &:after {
+        left: 0;
+        position: relative;
+      }
+    }
+
     &.button--round {
       text-transform: uppercase;
       border-radius: $dp-border-radius--lv1;

--- a/assets/scss/modules/_card.scss
+++ b/assets/scss/modules/_card.scss
@@ -247,6 +247,7 @@
     padding: 3px 5px;
     border-radius: 3px;
     font-size: 10px;
+    letter-spacing: 0.6px;
   }
   .dp-coming {
     background-color: #fcedec;
@@ -255,6 +256,6 @@
     padding: 4px 6px;
     border-radius: 3px;
     font-size: 9px;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.6px;
   }
 }

--- a/assets/templates/buttons-component.html
+++ b/assets/templates/buttons-component.html
@@ -410,6 +410,25 @@
                   </div>
                 </div>
 
+                <div class="col-sm-12 col-md-8 col-lg-3 m-b-12">
+                  <div class="dp-box-shadow dpsg-content-sample">
+                    <div class="buttons-card">
+                      <button
+                        type="button"
+                        class="
+                          dp-button
+                          button-medium
+                          primary-green
+                          button--centered-loading
+                        "
+                      ></button>
+                      <div class="button-description">
+                        <p><strong>Button Preload centrado</strong></p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
                 <div class="col-sm-12 col-md-8 col-lg-6 m-b-12">
                   <div class="dp-box-shadow dpsg-content-sample">
                     <div class="buttons-card">


### PR DESCRIPTION
Add button component with centered preload and letter spacing for new labels


![preload-centrado](https://user-images.githubusercontent.com/46735526/139110522-026ae6c7-4f3b-47b8-9647-a8b2f3a2783e.gif)


#Checklist

- [X] Check if there is a new color.
- [X] Create the color variable in the _colors.scss file.
- [X] Follow the color nomenclature.
- [X] Create the color class with its variable.
- [X] Create the color component in the html, show the name, color class and its exadecimal.
