### PR TITLE
fix: remove max width

### DIFF
--- a/assets/scss/modules/_forms.scss
+++ b/assets/scss/modules/_forms.scss
@@ -688,7 +688,6 @@
   .dp-input--radio {
     margin: $dp-spaces--lv1;
     display: inline-block;
-    max-width: 170px;
     height: 30px;
     position: relative;
 


### PR DESCRIPTION
Remove max width from radio button component
Related: https://github.com/MakingSense/Doppler/pull/8778

- [X] Check if there is a new color.
- [X] Create the color variable in the _colors.scss file.
- [X] Follow the color nomenclature.
- [X] Create the color class with its variable.
- [X] Create the color component in the html, show the name, color class and its exadecimal.
