### PR TITLE
fix: fix in message for user add orange color to button

### DIFF
--- a/assets/scss/templates/_messages-header.scss
+++ b/assets/scss/templates/_messages-header.scss
@@ -45,6 +45,9 @@
 
   .messages-container.warning {
     background: $dp-color-yellow;
+    .button {
+      color: $dp-color-yellow;
+    }
   }
 
   .messages-container.blocker {

--- a/assets/templates/account-message-component.html
+++ b/assets/templates/account-message-component.html
@@ -102,6 +102,9 @@
                   Thanks! We’ll contact you ASAP and if everything is fine,
                   you’ll be able to send your Campaign.
                 </p>
+                <a href="#" class="button button--light button--tiny"
+                  >Upgrade Now</a
+                >
               </div>
             </div>
             <div class="messages-container info">


### PR DESCRIPTION
See:
https://cdn.fromdoppler.com/doppler-ui-library/build1388/account-message-component.html


![button-orange](https://user-images.githubusercontent.com/46735526/141530190-d6cf7d60-5a5d-468a-a585-bb0615befea0.gif)


#Checklist

- [X] Check if there is a new color.
- [X] Create the color variable in the _colors.scss file.
- [X] Follow the color nomenclature.
- [X] Create the color class with its variable.
- [X] Create the color component in the html, show the name, color class and its exadecimal.
